### PR TITLE
Feature: Show recipe suggestions when IO dropped in empty space

### DIFF
--- a/site/src/components/main-panel/blueprint-panel.vue
+++ b/site/src/components/main-panel/blueprint-panel.vue
@@ -3,31 +3,32 @@ Author: Alexey Usov (dax@xdax.ru, https://github.com/doubleaxe)
 Please don't remove this comment if you use unmodified file
 -->
 <script setup lang="ts">
-import { ref, computed, reactive, unref, watch, onMounted } from "vue";
+import {ref, computed, reactive, unref, watch, onMounted} from 'vue';
+import type {RecipeIOModel} from '@/scripts/model/store';
 import {
-  injectBlueprintModel,
-  type BlueprintItemModel,
-} from "@/scripts/model/store";
-import { injectSettings } from "@/scripts/settings";
-import RecipesMenu from "./recipes-menu.vue";
-import RecipeSuggestionMenu from "./recipe-suggestion-menu.vue";
-import { syncRefs, useEventListener, type MaybeElement } from "@vueuse/core";
+    injectBlueprintModel,
+    type BlueprintItemModel,
+} from '@/scripts/model/store';
+import {injectSettings} from '@/scripts/settings';
+import RecipesMenu from './recipes-menu.vue';
+import RecipeSuggestionMenu from './recipe-suggestion-menu.vue';
+import {syncRefs, useEventListener, type MaybeElement} from '@vueuse/core';
 import {
-  SelectedClassType,
-  useDragAndScroll,
-  useItemDragAndDrop,
-  useLeftPanelDragAndDrop,
-  useLinkDragAndDrop,
-  useOverflowScroll,
-  usePointAndClick,
-  useSharedBlueprintSurface,
-  screenToClient,
-} from "@/composables/drag-helpers";
-import { useEventHook } from "@/composables";
-import { injectFilter } from "@/scripts/filter";
-import { Rect, type ReadonlyPointType } from "@/scripts/geometry";
-import type { GameItem, GameRecipe } from "#types/game-data";
-import { buildTransformStyle } from "@/scripts/util";
+    SelectedClassType,
+    useDragAndScroll,
+    useItemDragAndDrop,
+    useLeftPanelDragAndDrop,
+    useLinkDragAndDrop,
+    useOverflowScroll,
+    usePointAndClick,
+    useSharedBlueprintSurface,
+    screenToClient,
+} from '@/composables/drag-helpers';
+import {useEventHook} from '@/composables';
+import {injectFilter} from '@/scripts/filter';
+import {Rect, type ReadonlyPointType} from '@/scripts/geometry';
+import type {GameItem, GameRecipe} from '#types/game-data';
+import {buildTransformStyle} from '@/scripts/util';
 
 const settings = injectSettings();
 const filter = injectFilter();
@@ -38,274 +39,272 @@ const recipesMenuElement = ref<InstanceType<typeof RecipesMenu> | null>(null);
 const recipeSuggestionMenuElement = ref<InstanceType<
   typeof RecipeSuggestionMenu
 > | null>(null);
-let lastDroppedOutputProductName: string | undefined = undefined;
 //detects if screen was scrolled between pointer down and click, don't perform anything if was scrolled
 let wasScrolled = false;
 
-const { onStart: startDragAndScroll } = useDragAndScroll();
+const {onStart: startDragAndScroll} = useDragAndScroll();
 useOverflowScroll(blueprintSurface);
 const {
-  hooks: leftPanelHooks,
-  dropZoneSurfaceElem: dropZoneSurfaceElem1,
-  dropZoneOriginElem: dropZoneOriginElem1,
+    hooks: leftPanelHooks,
+    dropZoneSurfaceElem: dropZoneSurfaceElem1,
+    dropZoneOriginElem: dropZoneOriginElem1,
 } = useLeftPanelDragAndDrop();
 const {
-  dropZoneSurfaceElem: dropZoneSurfaceElem2,
-  dropZoneOriginElem: dropZoneOriginElem2,
+    dropZoneSurfaceElem: dropZoneSurfaceElem2,
+    dropZoneOriginElem: dropZoneOriginElem2,
 } = useLinkDragAndDrop();
 const {
-  hooks: itemHooks,
-  dropZoneSurfaceElem: dropZoneSurfaceElem3,
-  dropZoneOriginElem: dropZoneOriginElem3,
+    hooks: itemHooks,
+    dropZoneSurfaceElem: dropZoneSurfaceElem3,
+    dropZoneOriginElem: dropZoneOriginElem3,
 } = useItemDragAndDrop();
 const {
-  processSelected,
-  parentElem: dropZoneOriginElem4,
-  notifySelected,
+    processSelected,
+    parentElem: dropZoneOriginElem4,
+    notifySelected,
 } = usePointAndClick();
-const { surfaceElem, originElem, updateSurface, boundingRect } =
+const {surfaceElem, originElem, updateSurface, boundingRect} =
   useSharedBlueprintSurface();
 
 syncRefs(blueprintSurface, [
-  surfaceElem,
-  dropZoneSurfaceElem1,
-  dropZoneSurfaceElem2,
-  dropZoneSurfaceElem3,
+    surfaceElem,
+    dropZoneSurfaceElem1,
+    dropZoneSurfaceElem2,
+    dropZoneSurfaceElem3,
 ]);
 syncRefs(blueprintCollection, [
-  originElem,
-  dropZoneOriginElem1,
-  dropZoneOriginElem2,
-  dropZoneOriginElem3,
-  dropZoneOriginElem4,
+    originElem,
+    dropZoneOriginElem1,
+    dropZoneOriginElem2,
+    dropZoneOriginElem3,
+    dropZoneOriginElem4,
 ]);
 
 function addItem(selected: GameItem, clientPosition: ReadonlyPointType) {
-  const item = reactive(blueprintModel.addItem(selected.name));
-  item.setRect(item.rect.assignPoint(clientPosition));
-  if (filter.key) {
-    const preselectRecipe = item.possibleRecipeForItem(
-      filter.key,
-      filter.direction
-    );
-    if (preselectRecipe) item.selectRecipe(preselectRecipe);
-  }
+    const item = reactive(blueprintModel.addItem(selected.name));
+    item.setRect(item.rect.assignPoint(clientPosition));
+    if(filter.key) {
+        const preselectRecipe = item.possibleRecipeForItem(
+            filter.key,
+            filter.direction,
+        );
+        if(preselectRecipe) item.selectRecipe(preselectRecipe);
+    }
 }
 useEventHook(leftPanelHooks.notifyDrop, (param) =>
-  addItem(param.item, param.clientRect)
+    addItem(param.item, param.clientRect),
 );
 
 useEventHook(notifySelected, (param) => {
-  if (wasScrolled) {
-    return;
-  }
-  if (param.item.clazz == SelectedClassType.Item) {
-    addItem(param.item.item as GameItem, param.clientPosition);
-    param.wasHandled();
-    return;
-  }
-  if (param.item.clazz == SelectedClassType.BlueprintItemModel) {
-    const item = param.item.item as BlueprintItemModel;
-    item.setRect(
-      item.rect.assignPoint(param.clientPosition).limit(unref(boundingRect))
-    );
-    param.wasHandled();
-    return;
-  }
+    if(wasScrolled) {
+        return;
+    }
+    if(param.item.clazz == SelectedClassType.Item) {
+        addItem(param.item.item as GameItem, param.clientPosition);
+        param.wasHandled();
+        return;
+    }
+    if(param.item.clazz == SelectedClassType.BlueprintItemModel) {
+        const item = param.item.item as BlueprintItemModel;
+        item.setRect(
+            item.rect.assignPoint(param.clientPosition).limit(unref(boundingRect)),
+        );
+        param.wasHandled();
+        return;
+    }
 });
 
 useEventHook([itemHooks.notifyMove, itemHooks.notifyDrop], (param) => {
-  const item = param.item;
-  item.setRect(
-    item.rect.assignPoint(param.clientRect).limit(unref(boundingRect))
-  );
-  if (param.event == "notifyDrop") {
-    updateSurface(blueprintModel.items);
-  }
+    const item = param.item;
+    item.setRect(
+        item.rect.assignPoint(param.clientRect).limit(unref(boundingRect)),
+    );
+    if(param.event == 'notifyDrop') {
+        updateSurface(blueprintModel.items);
+    }
 });
 
 const scaleStyle = computed(() => {
-  return {
-    transform: buildTransformStyle({ scale: String(settings.scale) }),
-  };
+    return {
+        transform: buildTransformStyle({scale: String(settings.scale)}),
+    };
 });
 
 watch(
-  [() => blueprintModel.itemsGenerationNumber, () => settings.scale],
-  () => {
+    [() => blueprintModel.itemsGenerationNumber, () => settings.scale],
+    () => {
     //on blueprint load reset scroll position
-    const resetScroll = !blueprintModel.itemsGenerationNumber;
-    updateSurface(blueprintModel.items, resetScroll);
-  }
+        const resetScroll = !blueprintModel.itemsGenerationNumber;
+        updateSurface(blueprintModel.items, resetScroll);
+    },
 );
 
 function handleScale(event: WheelEvent) {
-  if (settings.scrollScaleEnabled) {
-    if (event.deltaY < 0) {
-      settings.scale = Math.min(settings.scale + 0.1, 2);
-    } else {
-      settings.scale = Math.max(settings.scale - 0.1, 0.2);
+    if(settings.scrollScaleEnabled) {
+        if(event.deltaY < 0) {
+            settings.scale = Math.min(settings.scale + 0.1, 2);
+        } else {
+            settings.scale = Math.max(settings.scale - 0.1, 0.2);
+        }
+        event.stopPropagation();
+        event.preventDefault();
     }
-    event.stopPropagation();
-    event.preventDefault();
-  }
 }
 
 useEventListener(
-  "scroll",
-  () => {
-    wasScrolled = true;
-  },
-  { capture: true, passive: true }
+    'scroll',
+    () => {
+        wasScrolled = true;
+    },
+    {capture: true, passive: true},
 );
 onMounted(() => {
-  updateSurface(blueprintModel.items);
+    updateSurface(blueprintModel.items);
 });
 
 // Handle output dropped in empty space - show recipe suggestions for consumers
 function handleOutputDroppedEmpty(
-  productName: string,
-  sourceItemId: string,
-  screenPosition: ReadonlyPointType
+    productName: string,
+    sourceItemId: string,
+    screenPosition: ReadonlyPointType,
 ) {
-  lastDroppedOutputProductName = productName;
-  recipeSuggestionMenuElement.value?.activate(
-    productName,
-    sourceItemId,
-    screenPosition,
-    "consuming"
-  );
+    recipeSuggestionMenuElement.value?.activate(
+        productName,
+        sourceItemId,
+        screenPosition,
+        'consuming',
+    );
 }
 
 // Handle input dropped in empty space - show recipe suggestions for producers
 function handleInputDroppedEmpty(
-  productName: string,
-  sourceItemId: string,
-  screenPosition: ReadonlyPointType
+    productName: string,
+    sourceItemId: string,
+    screenPosition: ReadonlyPointType,
 ) {
-  recipeSuggestionMenuElement.value?.activate(
-    productName,
-    sourceItemId,
-    screenPosition,
-    "producing"
-  );
+    recipeSuggestionMenuElement.value?.activate(
+        productName,
+        sourceItemId,
+        screenPosition,
+        'producing',
+    );
 }
 
 // Handle recipe selected from suggestion menu - create factory and link
 function handleRecipeSelected(
-  factory: GameItem,
-  recipe: GameRecipe,
-  productName: string,
-  sourceItemId: string,
-  screenPosition: ReadonlyPointType,
-  mode: "consuming" | "producing"
+    factory: GameItem,
+    recipe: GameRecipe,
+    productName: string,
+    sourceItemId: string,
+    screenPosition: ReadonlyPointType,
+    mode: 'consuming' | 'producing',
 ) {
-  // Get the collection element for position calculation
-  const collectionEl = unref(blueprintCollection) as HTMLElement | null;
-  if (!collectionEl) return;
+    // Get the collection element for position calculation
+    const collectionEl = unref(blueprintCollection) as HTMLElement | null;
+    if(!collectionEl) return;
 
-  // Convert screen position to client position (accounting for scale)
-  const clientPosition = screenToClient(
-    collectionEl,
-    Rect.assign(screenPosition),
-    settings.scale
-  );
+    // Convert screen position to client position (accounting for scale)
+    const clientPosition = screenToClient(
+        collectionEl,
+        Rect.assign(screenPosition),
+        settings.scale,
+    );
 
-  // Create new factory item
-  const newItem = reactive(blueprintModel.addItem(factory.name));
+    // Create new factory item
+    const newItem = reactive(blueprintModel.addItem(factory.name));
 
-  // Position the factory at the drop location
-  newItem.setRect(
-    newItem.rect.assignPoint(clientPosition).limit(unref(boundingRect))
-  );
+    // Position the factory at the drop location
+    newItem.setRect(
+        newItem.rect.assignPoint(clientPosition).limit(unref(boundingRect)),
+    );
 
-  // Select the specific recipe
-  newItem.selectRecipe(recipe.name);
+    // Select the specific recipe
+    newItem.selectRecipe(recipe.name);
 
-  // Find the exact source/target item by ID
-  const linkedItem = blueprintModel.itemByKey(sourceItemId);
-  if (!linkedItem) return;
+    // Find the exact source/target item by ID
+    const linkedItem = blueprintModel.itemByKey(sourceItemId);
+    if(!linkedItem) return;
 
-  if (mode === "consuming") {
+    if(mode === 'consuming') {
     // We created a consumer (newItem), linkedItem is the producer (source)
-    const outputs = linkedItem.selectedRecipe?.visibleOutput() || [];
-    for (const output of outputs) {
-      if (output.name === productName) {
-        // Found the source output - create link to new factory
-        newItem.createLink(output);
-        updateSurface(blueprintModel.items);
-        return;
-      }
-    }
-  } else {
+        const outputs = linkedItem.selectedRecipe?.visibleOutput() || [];
+        for(const output of outputs) {
+            if(output.name === productName) {
+                // Found the source output - create link to new factory
+                newItem.createLink(output);
+                updateSurface(blueprintModel.items);
+                return;
+            }
+        }
+    } else {
     // Mode is 'producing', we created a producer (newItem), linkedItem is the consumer (target)
-    const inputs = linkedItem.selectedRecipe?.visibleInput() || [];
-    for (const input of inputs) {
-      if (input.name === productName) {
-        // Found the target input - link new factory's output to it
-        linkedItem.createLink(
-          newItem.selectedRecipe
-            ?.visibleOutput()
-            ?.find((o) => o.name === productName) as any
-        );
-        updateSurface(blueprintModel.items);
-        return;
-      }
+        const inputs = linkedItem.selectedRecipe?.visibleInput() || [];
+        for(const input of inputs) {
+            if(input.name === productName) {
+                // Found the target input - link new factory's output to it
+                linkedItem.createLink(
+                    newItem.selectedRecipe
+                    ?.visibleOutput()
+                    ?.find((o) => o.name === productName) as RecipeIOModel,
+                );
+                updateSurface(blueprintModel.items);
+                return;
+            }
+        }
     }
-  }
 }
 </script>
 
 <template>
-  <div
-    ref="blueprintSurface"
-    class="blueprint-surface"
-    @pointerdown.left="
-      startDragAndScroll($event);
-      wasScrolled = false;
-    "
-    @click="processSelected($event)"
-    @wheel="handleScale"
-  >
     <div
-      ref="blueprintCollection"
-      class="blueprint-collection"
-      :style="scaleStyle"
+        ref="blueprintSurface"
+        class="blueprint-surface"
+        @pointerdown.left="
+            startDragAndScroll($event);
+            wasScrolled = false;
+        "
+        @click="processSelected($event)"
+        @wheel="handleScale"
     >
-      <link-draggable
-        @output-dropped-empty="handleOutputDroppedEmpty"
-        @input-dropped-empty="handleInputDroppedEmpty"
-      />
-      <recipes-menu ref="recipesMenuElement" />
-      <recipe-suggestion-menu
-        ref="recipeSuggestionMenuElement"
-        @recipe-selected="handleRecipeSelected"
-      />
-      <blueprint-links />
-      <optimized-tooltip>
-        <template v-for="item in blueprintModel.items" :key="item.key">
-          <blueprint-single-item
-            :item="item"
-            :parent="blueprintCollection"
-            @recipes-menu-activate="recipesMenuElement?.activate"
-          />
-        </template>
-      </optimized-tooltip>
+        <div
+            ref="blueprintCollection"
+            class="blueprint-collection"
+            :style="scaleStyle"
+        >
+            <link-draggable
+                @output-dropped-empty="handleOutputDroppedEmpty"
+                @input-dropped-empty="handleInputDroppedEmpty"
+            />
+            <recipes-menu ref="recipesMenuElement" />
+            <recipe-suggestion-menu
+                ref="recipeSuggestionMenuElement"
+                @recipe-selected="handleRecipeSelected"
+            />
+            <blueprint-links />
+            <optimized-tooltip>
+                <template v-for="item in blueprintModel.items" :key="item.key">
+                    <blueprint-single-item
+                        :item="item"
+                        :parent="blueprintCollection"
+                        @recipes-menu-activate="recipesMenuElement?.activate"
+                    />
+                </template>
+            </optimized-tooltip>
+        </div>
     </div>
-  </div>
 </template>
 
 <style scoped>
 .blueprint-surface {
-  transform-origin: 0 0;
-  min-width: 100%;
-  min-height: 100%;
-  /* border: 1px solid red; */
+    transform-origin: 0 0;
+    min-width: 100%;
+    min-height: 100%;
+    /* border: 1px solid red; */
 }
 .blueprint-collection {
-  transform-origin: 0 0;
-  position: relative;
-  overflow: visible;
-  /* border: 1px solid green; */
+    transform-origin: 0 0;
+    position: relative;
+    overflow: visible;
+    /* border: 1px solid green; */
 }
 </style>

--- a/site/src/components/main-panel/blueprint-panel.vue
+++ b/site/src/components/main-panel/blueprint-panel.vue
@@ -3,26 +3,30 @@ Author: Alexey Usov (dax@xdax.ru, https://github.com/doubleaxe)
 Please don't remove this comment if you use unmodified file
 -->
 <script setup lang="ts">
-import {ref, computed, reactive, unref, watch, onMounted} from 'vue';
-import {injectBlueprintModel, type BlueprintItemModel} from '@/scripts/model/store';
-import {injectSettings} from '@/scripts/settings';
-import RecipesMenu from './recipes-menu.vue';
-import {syncRefs, useEventListener, type MaybeElement} from '@vueuse/core';
+import { ref, computed, reactive, unref, watch, onMounted } from "vue";
 import {
-    SelectedClassType,
-    useDragAndScroll,
-    useItemDragAndDrop,
-    useLeftPanelDragAndDrop,
-    useLinkDragAndDrop,
-    useOverflowScroll,
-    usePointAndClick,
-    useSharedBlueprintSurface,
-} from '@/composables/drag-helpers';
-import {useEventHook} from '@/composables';
-import {injectFilter} from '@/scripts/filter';
-import type {ReadonlyPointType} from '@/scripts/geometry';
-import type {GameItem} from '#types/game-data';
-import {buildTransformStyle} from '@/scripts/util';
+  injectBlueprintModel,
+  type BlueprintItemModel,
+} from "@/scripts/model/store";
+import { injectSettings } from "@/scripts/settings";
+import RecipesMenu from "./recipes-menu.vue";
+import RecipeSuggestionMenu from "./recipe-suggestion-menu.vue";
+import { syncRefs, useEventListener, type MaybeElement } from "@vueuse/core";
+import {
+  SelectedClassType,
+  useDragAndScroll,
+  useItemDragAndDrop,
+  useLeftPanelDragAndDrop,
+  useLinkDragAndDrop,
+  useOverflowScroll,
+  usePointAndClick,
+  useSharedBlueprintSurface,
+} from "@/composables/drag-helpers";
+import { useEventHook } from "@/composables";
+import { injectFilter } from "@/scripts/filter";
+import type { ReadonlyPointType } from "@/scripts/geometry";
+import type { GameItem, GameRecipe } from "#types/game-data";
+import { buildTransformStyle } from "@/scripts/util";
 
 const settings = injectSettings();
 const filter = injectFilter();
@@ -30,137 +34,223 @@ const blueprintModel = injectBlueprintModel();
 const blueprintSurface = ref<MaybeElement>(null);
 const blueprintCollection = ref<MaybeElement>(null);
 const recipesMenuElement = ref<InstanceType<typeof RecipesMenu> | null>(null);
+const recipeSuggestionMenuElement = ref<InstanceType<
+  typeof RecipeSuggestionMenu
+> | null>(null);
+let lastDroppedOutputProductName: string | undefined = undefined;
 //detects if screen was scrolled between pointer down and click, don't perform anything if was scrolled
 let wasScrolled = false;
 
-const {onStart: startDragAndScroll} = useDragAndScroll();
+const { onStart: startDragAndScroll } = useDragAndScroll();
 useOverflowScroll(blueprintSurface);
 const {
-    hooks: leftPanelHooks,
-    dropZoneSurfaceElem: dropZoneSurfaceElem1,
-    dropZoneOriginElem: dropZoneOriginElem1,
+  hooks: leftPanelHooks,
+  dropZoneSurfaceElem: dropZoneSurfaceElem1,
+  dropZoneOriginElem: dropZoneOriginElem1,
 } = useLeftPanelDragAndDrop();
-const {dropZoneSurfaceElem: dropZoneSurfaceElem2, dropZoneOriginElem: dropZoneOriginElem2} = useLinkDragAndDrop();
 const {
-    hooks: itemHooks,
-    dropZoneSurfaceElem: dropZoneSurfaceElem3,
-    dropZoneOriginElem: dropZoneOriginElem3,
+  dropZoneSurfaceElem: dropZoneSurfaceElem2,
+  dropZoneOriginElem: dropZoneOriginElem2,
+} = useLinkDragAndDrop();
+const {
+  hooks: itemHooks,
+  dropZoneSurfaceElem: dropZoneSurfaceElem3,
+  dropZoneOriginElem: dropZoneOriginElem3,
 } = useItemDragAndDrop();
-const {processSelected, parentElem: dropZoneOriginElem4, notifySelected} = usePointAndClick();
-const {surfaceElem, originElem, updateSurface, boundingRect} = useSharedBlueprintSurface();
+const {
+  processSelected,
+  parentElem: dropZoneOriginElem4,
+  notifySelected,
+} = usePointAndClick();
+const { surfaceElem, originElem, updateSurface, boundingRect } =
+  useSharedBlueprintSurface();
 
-syncRefs(blueprintSurface, [surfaceElem, dropZoneSurfaceElem1, dropZoneSurfaceElem2, dropZoneSurfaceElem3]);
-syncRefs(blueprintCollection, [originElem, dropZoneOriginElem1, dropZoneOriginElem2, dropZoneOriginElem3, dropZoneOriginElem4]);
+syncRefs(blueprintSurface, [
+  surfaceElem,
+  dropZoneSurfaceElem1,
+  dropZoneSurfaceElem2,
+  dropZoneSurfaceElem3,
+]);
+syncRefs(blueprintCollection, [
+  originElem,
+  dropZoneOriginElem1,
+  dropZoneOriginElem2,
+  dropZoneOriginElem3,
+  dropZoneOriginElem4,
+]);
 
 function addItem(selected: GameItem, clientPosition: ReadonlyPointType) {
-    const item = reactive(blueprintModel.addItem(selected.name));
-    item.setRect(item.rect.assignPoint(clientPosition));
-    if(filter.key) {
-        const preselectRecipe = item.possibleRecipeForItem(filter.key, filter.direction);
-        if(preselectRecipe)
-            item.selectRecipe(preselectRecipe);
-    }
+  const item = reactive(blueprintModel.addItem(selected.name));
+  item.setRect(item.rect.assignPoint(clientPosition));
+  if (filter.key) {
+    const preselectRecipe = item.possibleRecipeForItem(
+      filter.key,
+      filter.direction
+    );
+    if (preselectRecipe) item.selectRecipe(preselectRecipe);
+  }
 }
-useEventHook(leftPanelHooks.notifyDrop, (param) => addItem(param.item, param.clientRect));
+useEventHook(leftPanelHooks.notifyDrop, (param) =>
+  addItem(param.item, param.clientRect)
+);
 
 useEventHook(notifySelected, (param) => {
-    if(wasScrolled) {
-        return;
-    }
-    if(param.item.clazz == SelectedClassType.Item) {
-        addItem(param.item.item as GameItem, param.clientPosition);
-        param.wasHandled();
-        return;
-    }
-    if(param.item.clazz == SelectedClassType.BlueprintItemModel) {
-        const item = param.item.item as BlueprintItemModel;
-        item.setRect(item.rect.assignPoint(param.clientPosition).limit(unref(boundingRect)));
-        param.wasHandled();
-        return;
-    }
+  if (wasScrolled) {
+    return;
+  }
+  if (param.item.clazz == SelectedClassType.Item) {
+    addItem(param.item.item as GameItem, param.clientPosition);
+    param.wasHandled();
+    return;
+  }
+  if (param.item.clazz == SelectedClassType.BlueprintItemModel) {
+    const item = param.item.item as BlueprintItemModel;
+    item.setRect(
+      item.rect.assignPoint(param.clientPosition).limit(unref(boundingRect))
+    );
+    param.wasHandled();
+    return;
+  }
 });
 
 useEventHook([itemHooks.notifyMove, itemHooks.notifyDrop], (param) => {
-    const item = param.item;
-    item.setRect(item.rect.assignPoint(param.clientRect).limit(unref(boundingRect)));
-    if(param.event == 'notifyDrop') {
-        updateSurface(blueprintModel.items);
-    }
+  const item = param.item;
+  item.setRect(
+    item.rect.assignPoint(param.clientRect).limit(unref(boundingRect))
+  );
+  if (param.event == "notifyDrop") {
+    updateSurface(blueprintModel.items);
+  }
 });
 
 const scaleStyle = computed(() => {
-    return {
-        transform: buildTransformStyle({scale: String(settings.scale)}),
-    };
+  return {
+    transform: buildTransformStyle({ scale: String(settings.scale) }),
+  };
 });
 
-watch([() => blueprintModel.itemsGenerationNumber, () => settings.scale], () => {
+watch(
+  [() => blueprintModel.itemsGenerationNumber, () => settings.scale],
+  () => {
     //on blueprint load reset scroll position
     const resetScroll = !blueprintModel.itemsGenerationNumber;
     updateSurface(blueprintModel.items, resetScroll);
-});
+  }
+);
 
 function handleScale(event: WheelEvent) {
-    if(settings.scrollScaleEnabled) {
-        if(event.deltaY < 0) {
-            settings.scale = Math.min(settings.scale + 0.1, 2);
-        } else {
-            settings.scale = Math.max(settings.scale - 0.1, 0.2);
-        }
-        event.stopPropagation();
-        event.preventDefault();
+  if (settings.scrollScaleEnabled) {
+    if (event.deltaY < 0) {
+      settings.scale = Math.min(settings.scale + 0.1, 2);
+    } else {
+      settings.scale = Math.max(settings.scale - 0.1, 0.2);
     }
+    event.stopPropagation();
+    event.preventDefault();
+  }
 }
 
-useEventListener('scroll', () => { wasScrolled = true; }, {capture: true, passive: true});
+useEventListener(
+  "scroll",
+  () => {
+    wasScrolled = true;
+  },
+  { capture: true, passive: true }
+);
 onMounted(() => {
-    updateSurface(blueprintModel.items);
+  updateSurface(blueprintModel.items);
 });
+
+// Handle output dropped in empty space - show recipe suggestions
+function handleOutputDroppedEmpty(
+  productName: string,
+  screenPosition: ReadonlyPointType
+) {
+  lastDroppedOutputProductName = productName;
+  recipeSuggestionMenuElement.value?.activate(productName, screenPosition);
+}
+
+// Handle recipe selected from suggestion menu - create factory and link
+function handleRecipeSelected(
+  factory: GameItem,
+  recipe: GameRecipe,
+  productName: string
+) {
+  // Get the surface element for position calculation
+  const surfaceEl = unref(blueprintSurface) as HTMLElement | null;
+  if (!surfaceEl) return;
+
+  // Create new factory item at a default position (will be placed near center)
+  const newItem = reactive(blueprintModel.addItem(factory.name));
+
+  // Select the specific recipe
+  newItem.selectRecipe(recipe.name);
+
+  // Find the source item that has the output we want to link
+  // and create the link
+  for (const existingItem of blueprintModel.items) {
+    if (existingItem === newItem) continue;
+    const outputs = existingItem.selectedRecipe?.visibleOutput() || [];
+    for (const output of outputs) {
+      if (output.name === productName) {
+        // Found the source output - create link to new factory
+        newItem.createLink(output);
+        // Update surface to recalculate bounds
+        updateSurface(blueprintModel.items);
+        return;
+      }
+    }
+  }
+}
 </script>
 
 <template>
+  <div
+    ref="blueprintSurface"
+    class="blueprint-surface"
+    @pointerdown.left="
+      startDragAndScroll($event);
+      wasScrolled = false;
+    "
+    @click="processSelected($event)"
+    @wheel="handleScale"
+  >
     <div
-        ref="blueprintSurface"
-        class="blueprint-surface"
-        @pointerdown.left="startDragAndScroll($event); wasScrolled = false;"
-        @click="processSelected($event)"
-        @wheel="handleScale"
+      ref="blueprintCollection"
+      class="blueprint-collection"
+      :style="scaleStyle"
     >
-        <div
-            ref="blueprintCollection"
-            class="blueprint-collection"
-            :style="scaleStyle"
-        >
-            <link-draggable />
-            <recipes-menu ref="recipesMenuElement" />
-            <blueprint-links />
-            <optimized-tooltip>
-                <template
-                    v-for="item in blueprintModel.items"
-                    :key="item.key"
-                >
-                    <blueprint-single-item
-                        :item="item"
-                        :parent="blueprintCollection"
-                        @recipes-menu-activate="recipesMenuElement?.activate"
-                    />
-                </template>
-            </optimized-tooltip>
-        </div>
+      <link-draggable @output-dropped-empty="handleOutputDroppedEmpty" />
+      <recipes-menu ref="recipesMenuElement" />
+      <recipe-suggestion-menu
+        ref="recipeSuggestionMenuElement"
+        @recipe-selected="handleRecipeSelected"
+      />
+      <blueprint-links />
+      <optimized-tooltip>
+        <template v-for="item in blueprintModel.items" :key="item.key">
+          <blueprint-single-item
+            :item="item"
+            :parent="blueprintCollection"
+            @recipes-menu-activate="recipesMenuElement?.activate"
+          />
+        </template>
+      </optimized-tooltip>
     </div>
+  </div>
 </template>
 
 <style scoped>
 .blueprint-surface {
-    transform-origin: 0 0;
-    min-width: 100%;
-    min-height: 100%;
-    /* border: 1px solid red; */
+  transform-origin: 0 0;
+  min-width: 100%;
+  min-height: 100%;
+  /* border: 1px solid red; */
 }
 .blueprint-collection {
-    transform-origin: 0 0;
-    position: relative;
-    overflow: visible;
-    /* border: 1px solid green; */
+  transform-origin: 0 0;
+  position: relative;
+  overflow: visible;
+  /* border: 1px solid green; */
 }
 </style>

--- a/site/src/components/main-panel/link-draggable.vue
+++ b/site/src/components/main-panel/link-draggable.vue
@@ -3,47 +3,47 @@ Author: Alexey Usov (dax@xdax.ru, https://github.com/doubleaxe)
 Please don't remove this comment if you use unmodified file
 -->
 <script setup lang="ts">
-import { unref, computed, reactive, toRaw, ref, watch, nextTick } from "vue";
+import {unref, computed, reactive, toRaw, ref, watch, nextTick} from 'vue';
 import {
-  injectBlueprintModel,
-  type BlueprintItemModel,
-  type RecipeIOModel,
-} from "@/scripts/model/store";
-import { Rect, type ReadonlyPointType } from "@/scripts/geometry";
+    injectBlueprintModel,
+    type BlueprintItemModel,
+    type RecipeIOModel,
+} from '@/scripts/model/store';
+import {Rect, type ReadonlyPointType} from '@/scripts/geometry';
 import {
-  BlueprintItemState,
-  type BlueprintItemStateValues,
-} from "@/scripts/types";
+    BlueprintItemState,
+    type BlueprintItemStateValues,
+} from '@/scripts/types';
 import {
-  screenToClient,
-  SelectedClassType,
-  useLinkDragAndDrop,
-  usePointAndClick,
-  useSharedBlueprintSurface,
-} from "@/composables/drag-helpers";
-import { useEventHook } from "@/composables";
-import { injectSettings } from "@/scripts/settings";
+    screenToClient,
+    SelectedClassType,
+    useLinkDragAndDrop,
+    usePointAndClick,
+    useSharedBlueprintSurface,
+} from '@/composables/drag-helpers';
+import {useEventHook} from '@/composables';
+import {injectSettings} from '@/scripts/settings';
 
 const emit = defineEmits<{
-  (
-    e: "output-dropped-empty",
-    productName: string,
-    sourceItemId: string,
-    screenPosition: ReadonlyPointType
-  ): void;
-  (
-    e: "input-dropped-empty",
-    productName: string,
-    sourceItemId: string,
-    screenPosition: ReadonlyPointType
-  ): void;
+    (
+        e: 'output-dropped-empty',
+        productName: string,
+        sourceItemId: string,
+        screenPosition: ReadonlyPointType
+    ): void;
+    (
+        e: 'input-dropped-empty',
+        productName: string,
+        sourceItemId: string,
+        screenPosition: ReadonlyPointType
+    ): void;
 }>();
 
 type BetweenSelfIo = {
-  upper?: RecipeIOModel;
-  upperIndex?: number;
-  lower?: RecipeIOModel;
-  lowerIndex?: number;
+    upper?: RecipeIOModel;
+    upperIndex?: number;
+    lower?: RecipeIOModel;
+    lowerIndex?: number;
 };
 
 const blueprintModel = injectBlueprintModel();
@@ -51,309 +51,309 @@ const settings = injectSettings();
 let hoveringItem: BlueprintItemModel | undefined = undefined;
 let hoveringBetweenIo: BetweenSelfIo | undefined = undefined;
 
-const { hooks, isDragging, currentItem, movableElem } = useLinkDragAndDrop();
-const { notifySelected } = usePointAndClick();
-const { boundingRect } = useSharedBlueprintSurface();
+const {hooks, isDragging, currentItem, movableElem} = useLinkDragAndDrop();
+const {notifySelected} = usePointAndClick();
+const {boundingRect} = useSharedBlueprintSurface();
 
-const draggableClass = ref("");
+const draggableClass = ref('');
 const draggableStyle = computed(() => {
-  const _isDragging = unref(isDragging);
-  const _dragRect = unref(currentItem)?.dragging?.rect;
-  //keep far offscreen, so drag-n-drop processor could get width and height
-  if (!_isDragging || !_dragRect) {
-    return {};
-  }
-  return {
-    left: `${_dragRect.x}px`,
-    top: `${_dragRect.y}px`,
-  };
+    const _isDragging = unref(isDragging);
+    const _dragRect = unref(currentItem)?.dragging?.rect;
+    //keep far offscreen, so drag-n-drop processor could get width and height
+    if(!_isDragging || !_dragRect) {
+        return {};
+    }
+    return {
+        left: `${_dragRect.x}px`,
+        top: `${_dragRect.y}px`,
+    };
 });
 
 watch(
-  isDragging,
-  (value) => {
-    if (!value) {
-      draggableClass.value = "link-draggable-hidden";
-    } else {
-      //this is against flickering, so first position is set, and next icon is shown
-      //otherwise it sometimes jump out of somewhere
-      nextTick(() => {
-        draggableClass.value = "";
-      });
-    }
-  },
-  { immediate: true }
+    isDragging,
+    (value) => {
+        if(!value) {
+            draggableClass.value = 'link-draggable-hidden';
+        } else {
+            //this is against flickering, so first position is set, and next icon is shown
+            //otherwise it sometimes jump out of somewhere
+            nextTick(() => {
+                draggableClass.value = '';
+            });
+        }
+    },
+    {immediate: true},
 );
 
 function clearHoveringItem() {
-  if (hoveringItem) {
-    hoveringItem.updateLinkState();
-    hoveringItem = undefined;
-  }
+    if(hoveringItem) {
+        hoveringItem.updateLinkState();
+        hoveringItem = undefined;
+    }
 }
 
 function clearHoveringBetweenIo() {
-  if (hoveringBetweenIo) {
-    if (hoveringBetweenIo.lower) {
-      hoveringBetweenIo.lower.setHighlightBorder(0);
+    if(hoveringBetweenIo) {
+        if(hoveringBetweenIo.lower) {
+            hoveringBetweenIo.lower.setHighlightBorder(0);
+        }
+        if(hoveringBetweenIo.upper) {
+            hoveringBetweenIo.upper.setHighlightBorder(0);
+        }
+        hoveringBetweenIo = undefined;
     }
-    if (hoveringBetweenIo.upper) {
-      hoveringBetweenIo.upper.setHighlightBorder(0);
-    }
-    hoveringBetweenIo = undefined;
-  }
 }
 
 type BlueprintItemWithElement = {
-  item: BlueprintItemModel;
-  element: HTMLElement;
+    item: BlueprintItemModel;
+    element: HTMLElement;
 };
 function detectItemFromPoint(screenPoint: ReadonlyPointType) {
-  const elements = document.elementsFromPoint(screenPoint.x, screenPoint.y);
-  let item: Partial<BlueprintItemWithElement> = {};
-  elements.find((element) => {
-    const itemId = element.getAttribute("data-item-id");
-    if (itemId) {
-      const blueprintItem = blueprintModel.itemByKey(itemId);
-      if (blueprintItem) {
-        item = { item: blueprintItem, element: element as HTMLElement };
-        return true;
-      }
-    }
-    return false;
-  });
-  return item;
+    const elements = document.elementsFromPoint(screenPoint.x, screenPoint.y);
+    let item: Partial<BlueprintItemWithElement> = {};
+    elements.find((element) => {
+        const itemId = element.getAttribute('data-item-id');
+        if(itemId) {
+            const blueprintItem = blueprintModel.itemByKey(itemId);
+            if(blueprintItem) {
+                item = {item: blueprintItem, element: element as HTMLElement};
+                return true;
+            }
+        }
+        return false;
+    });
+    return item;
 }
 
 type SourceItemWithElement = {
-  sourceItem: BlueprintItemModel;
-  sourceElem: HTMLElement;
+    sourceItem: BlueprintItemModel;
+    sourceElem: HTMLElement;
 };
 function getSelfLinkNeighbourIo(
-  { sourceItem, sourceElem }: SourceItemWithElement,
-  sourceIo: RecipeIOModel,
-  screenPoint: ReadonlyPointType
+    {sourceItem, sourceElem}: SourceItemWithElement,
+    sourceIo: RecipeIOModel,
+    screenPoint: ReadonlyPointType,
 ) {
-  const clientPoint = screenToClient(
-    sourceElem,
-    Rect.assign(screenPoint),
-    settings.scale
-  ).offsetBy(sourceItem.rect);
-  //check if mouse point is between io rects
-  const neighbourIo =
+    const clientPoint = screenToClient(
+        sourceElem,
+        Rect.assign(screenPoint),
+        settings.scale,
+    ).offsetBy(sourceItem.rect);
+    //check if mouse point is between io rects
+    const neighbourIo =
     (sourceIo.isInput
-      ? sourceItem.selectedRecipe?.visibleInput()
-      : sourceItem.selectedRecipe?.visibleOutput()) || [];
+        ? sourceItem.selectedRecipe?.visibleInput()
+        : sourceItem.selectedRecipe?.visibleOutput()) || [];
 
-  const betweenIo: BetweenSelfIo = {};
-  for (let i = 0; i < neighbourIo.length; i++) {
-    const io1 = neighbourIo[i];
-    const midPoint1 = io1.rect.middleRectPoint();
-    //if midpoint is above client rect, then mouse is in between this io and previous io
-    if (midPoint1.y > clientPoint.y) {
-      betweenIo.lowerIndex = i;
-      betweenIo.lower = io1;
-      if (i > 0) {
-        betweenIo.upperIndex = i - 1;
-        betweenIo.upper = neighbourIo[betweenIo.upperIndex];
-      }
-      break;
+    const betweenIo: BetweenSelfIo = {};
+    for(let i = 0; i < neighbourIo.length; i++) {
+        const io1 = neighbourIo[i];
+        const midPoint1 = io1.rect.middleRectPoint();
+        //if midpoint is above client rect, then mouse is in between this io and previous io
+        if(midPoint1.y > clientPoint.y) {
+            betweenIo.lowerIndex = i;
+            betweenIo.lower = io1;
+            if(i > 0) {
+                betweenIo.upperIndex = i - 1;
+                betweenIo.upper = neighbourIo[betweenIo.upperIndex];
+            }
+            break;
+        }
     }
-  }
-  //if lower is found, then mouse is below last io
-  if (!betweenIo.lower) {
-    betweenIo.upperIndex = neighbourIo.length - 1;
-    betweenIo.upper = neighbourIo[betweenIo.upperIndex];
-  }
-  return betweenIo;
+    //if lower is found, then mouse is below last io
+    if(!betweenIo.lower) {
+        betweenIo.upperIndex = neighbourIo.length - 1;
+        betweenIo.upper = neighbourIo[betweenIo.upperIndex];
+    }
+    return betweenIo;
 }
 
 function processSelfLinkInsertionPoint(betweenIo: BetweenSelfIo) {
-  if (!betweenIo.upper && !betweenIo.lower) {
+    if(!betweenIo.upper && !betweenIo.lower) {
     //impossible, maybe exactly midpoint
-    clearHoveringBetweenIo();
-    return;
-  }
-  if (
-    betweenIo.lowerIndex === hoveringBetweenIo?.lowerIndex &&
+        clearHoveringBetweenIo();
+        return;
+    }
+    if(
+        betweenIo.lowerIndex === hoveringBetweenIo?.lowerIndex &&
     betweenIo.upperIndex === hoveringBetweenIo?.upperIndex
-  ) {
-    return;
-  }
-  clearHoveringBetweenIo();
-  //on lower io highlight upper border
-  betweenIo.lower?.setHighlightBorder(1);
-  betweenIo.upper?.setHighlightBorder(-1);
-  hoveringBetweenIo = betweenIo;
+    ) {
+        return;
+    }
+    clearHoveringBetweenIo();
+    //on lower io highlight upper border
+    betweenIo.lower?.setHighlightBorder(1);
+    betweenIo.upper?.setHighlightBorder(-1);
+    hoveringBetweenIo = betweenIo;
 }
 
 function processOtherFactoryLink(
-  sourceIo: RecipeIOModel,
-  draggingIo: RecipeIOModel,
-  targetItem: BlueprintItemModel
+    sourceIo: RecipeIOModel,
+    draggingIo: RecipeIOModel,
+    targetItem: BlueprintItemModel,
 ) {
-  hoveringItem = targetItem;
-  hoveringItem.updateLinkState(sourceIo);
-  draggingIo.setFlipped(targetItem.isFlipped);
+    hoveringItem = targetItem;
+    hoveringItem.updateLinkState(sourceIo);
+    draggingIo.setFlipped(targetItem.isFlipped);
 }
 
 function processTargetItem(
-  sourceItem: RecipeIOModel,
-  draggingItem: RecipeIOModel,
-  screenPoint: ReadonlyPointType
+    sourceItem: RecipeIOModel,
+    draggingItem: RecipeIOModel,
+    screenPoint: ReadonlyPointType,
 ) {
-  const { item, element } = detectItemFromPoint(screenPoint);
-  if (!item || !element) {
+    const {item, element} = detectItemFromPoint(screenPoint);
+    if(!item || !element) {
+        clearHoveringItem();
+        clearHoveringBetweenIo();
+        return;
+    }
+    if(toRaw(item) === toRaw(sourceItem?.ownerItem)) {
+        clearHoveringItem();
+        const betweenIo = getSelfLinkNeighbourIo(
+            {sourceItem: item, sourceElem: element},
+            sourceItem,
+            screenPoint,
+        );
+        processSelfLinkInsertionPoint(betweenIo);
+        return;
+    }
+    if(toRaw(item) === toRaw(hoveringItem)) {
+        return;
+    }
     clearHoveringItem();
     clearHoveringBetweenIo();
-    return;
-  }
-  if (toRaw(item) === toRaw(sourceItem?.ownerItem)) {
-    clearHoveringItem();
-    const betweenIo = getSelfLinkNeighbourIo(
-      { sourceItem: item, sourceElem: element },
-      sourceItem,
-      screenPoint
-    );
-    processSelfLinkInsertionPoint(betweenIo);
-    return;
-  }
-  if (toRaw(item) === toRaw(hoveringItem)) {
-    return;
-  }
-  clearHoveringItem();
-  clearHoveringBetweenIo();
-  processOtherFactoryLink(sourceItem, draggingItem, item);
+    processOtherFactoryLink(sourceItem, draggingItem, item);
 }
 
 function processSwapIo(betweenIo: BetweenSelfIo, sourceIo: RecipeIOModel) {
-  if (!betweenIo.upper && !betweenIo.lower) {
-    return false;
-  }
-  if (
-    toRaw(betweenIo.lower) === toRaw(sourceIo) ||
+    if(!betweenIo.upper && !betweenIo.lower) {
+        return false;
+    }
+    if(
+        toRaw(betweenIo.lower) === toRaw(sourceIo) ||
     toRaw(betweenIo.upper) === toRaw(sourceIo)
-  ) {
-    return false;
-  }
-  const selectedRecipe = sourceIo.ownerItem?.selectedRecipe;
-  if (!selectedRecipe) {
-    return false;
-  }
-  selectedRecipe.swapIo(sourceIo.key, [
-    betweenIo.upperIndex,
-    betweenIo.lowerIndex,
-  ]);
-  return true;
+    ) {
+        return false;
+    }
+    const selectedRecipe = sourceIo.ownerItem?.selectedRecipe;
+    if(!selectedRecipe) {
+        return false;
+    }
+    selectedRecipe.swapIo(sourceIo.key, [
+        betweenIo.upperIndex,
+        betweenIo.lowerIndex,
+    ]);
+    return true;
 }
 
 function processLink(
-  sourceItem: RecipeIOModel,
-  _hoveringItem: BlueprintItemModel,
-  hoveringState: BlueprintItemStateValues
+    sourceItem: RecipeIOModel,
+    _hoveringItem: BlueprintItemModel,
+    hoveringState: BlueprintItemStateValues,
 ) {
-  if (hoveringState === BlueprintItemState.CanLinkTarget) {
-    _hoveringItem.createLink(sourceItem);
-    return true;
-  } else if (hoveringState === BlueprintItemState.CanLinkWithRecipeChange) {
-    const recipe = _hoveringItem.possibleRecipeForIo(sourceItem);
-    if (recipe) {
-      _hoveringItem.selectRecipe(recipe);
-      _hoveringItem.createLink(sourceItem);
+    if(hoveringState === BlueprintItemState.CanLinkTarget) {
+        _hoveringItem.createLink(sourceItem);
+        return true;
+    } else if(hoveringState === BlueprintItemState.CanLinkWithRecipeChange) {
+        const recipe = _hoveringItem.possibleRecipeForIo(sourceItem);
+        if(recipe) {
+            _hoveringItem.selectRecipe(recipe);
+            _hoveringItem.createLink(sourceItem);
+        }
+        return true;
     }
-    return true;
-  }
-  return false;
+    return false;
 }
 
 useEventHook(hooks.notifyStart, (param) => {
-  const item = param.item;
-  const { link, target } = reactive(item.source.createTempLink());
-  target.setFlipped(item.source.isFlipped);
-  item.link = link;
-  item.dragging = target;
+    const item = param.item;
+    const {link, target} = reactive(item.source.createTempLink());
+    target.setFlipped(item.source.isFlipped);
+    item.link = link;
+    item.dragging = target;
 });
 
 useEventHook(hooks.notifyDrop, (param) => {
-  const sourceItem = param.item.source;
-  if (sourceItem && hoveringItem) {
-    processLink(sourceItem, hoveringItem, hoveringItem.state);
-  } else if (sourceItem && hoveringBetweenIo) {
-    processSwapIo(hoveringBetweenIo, sourceItem);
-  } else if (sourceItem && !sourceItem.isInput) {
+    const sourceItem = param.item.source;
+    if(sourceItem && hoveringItem) {
+        processLink(sourceItem, hoveringItem, hoveringItem.state);
+    } else if(sourceItem && hoveringBetweenIo) {
+        processSwapIo(hoveringBetweenIo, sourceItem);
+    } else if(sourceItem && !sourceItem.isInput) {
     // Output dropped in empty space - emit event to show consuming recipes
-    const productName = sourceItem.name;
-    const sourceItemId = sourceItem.ownerItem?.key;
-    if (productName && sourceItemId) {
-      emit("output-dropped-empty", productName, sourceItemId, param.screenRect);
-    }
-  } else if (sourceItem && sourceItem.isInput) {
+        const productName = sourceItem.name;
+        const sourceItemId = sourceItem.ownerItem?.key;
+        if(productName && sourceItemId) {
+            emit('output-dropped-empty', productName, sourceItemId, param.screenRect);
+        }
+    } else if(sourceItem && sourceItem.isInput) {
     // Input dropped in empty space - emit event to show producing recipes
-    const productName = sourceItem.name;
-    const sourceItemId = sourceItem.ownerItem?.key;
-    if (productName && sourceItemId) {
-      emit("input-dropped-empty", productName, sourceItemId, param.screenRect);
+        const productName = sourceItem.name;
+        const sourceItemId = sourceItem.ownerItem?.key;
+        if(productName && sourceItemId) {
+            emit('input-dropped-empty', productName, sourceItemId, param.screenRect);
+        }
     }
-  }
-  clearHoveringItem();
-  clearHoveringBetweenIo();
-  blueprintModel.clearTempLink();
+    clearHoveringItem();
+    clearHoveringBetweenIo();
+    blueprintModel.clearTempLink();
 });
 
 useEventHook(hooks.notifyCancel, () => blueprintModel.clearTempLink());
 
 useEventHook(hooks.notifyMove, (param) => {
-  const draggingItem = param.item.dragging;
-  if (draggingItem) {
-    draggingItem.setRect(param.clientRect.limit(unref(boundingRect)));
-    processTargetItem(param.item.source, draggingItem, param.screenRect);
-  }
+    const draggingItem = param.item.dragging;
+    if(draggingItem) {
+        draggingItem.setRect(param.clientRect.limit(unref(boundingRect)));
+        processTargetItem(param.item.source, draggingItem, param.screenRect);
+    }
 });
 
 useEventHook(notifySelected, (param) => {
-  if (param.item.clazz != SelectedClassType.RecipeIOModel) {
-    return;
-  }
-  const sourceItem = param.item.item as RecipeIOModel;
-  const { item: _hoveringItem, element } = detectItemFromPoint(
-    param.screenPosition
-  );
-  if (!_hoveringItem || !element) {
-    return;
-  }
-  if (toRaw(_hoveringItem) === toRaw(sourceItem?.ownerItem)) {
-    const betweenIo = getSelfLinkNeighbourIo(
-      { sourceItem: _hoveringItem, sourceElem: element },
-      sourceItem,
-      param.screenPosition
-    );
-    if (processSwapIo(betweenIo, sourceItem)) {
-      param.wasHandled();
+    if(param.item.clazz != SelectedClassType.RecipeIOModel) {
+        return;
     }
-    return;
-  }
-  const linkState = _hoveringItem.calculateLinkState(sourceItem);
-  if (processLink(sourceItem, _hoveringItem, linkState)) {
-    param.wasHandled();
-  }
+    const sourceItem = param.item.item as RecipeIOModel;
+    const {item: _hoveringItem, element} = detectItemFromPoint(
+        param.screenPosition,
+    );
+    if(!_hoveringItem || !element) {
+        return;
+    }
+    if(toRaw(_hoveringItem) === toRaw(sourceItem?.ownerItem)) {
+        const betweenIo = getSelfLinkNeighbourIo(
+            {sourceItem: _hoveringItem, sourceElem: element},
+            sourceItem,
+            param.screenPosition,
+        );
+        if(processSwapIo(betweenIo, sourceItem)) {
+            param.wasHandled();
+        }
+        return;
+    }
+    const linkState = _hoveringItem.calculateLinkState(sourceItem);
+    if(processLink(sourceItem, _hoveringItem, linkState)) {
+        param.wasHandled();
+    }
 });
 </script>
 
 <template>
-  <v-sheet
-    ref="movableElem"
-    class="rounded dragging-elevation link-draggable hover-background"
-    :class="draggableClass"
-    :style="draggableStyle"
-  >
-    <icon-component :image="currentItem?.source?.image || ''" />
-  </v-sheet>
+    <v-sheet
+        ref="movableElem"
+        class="rounded dragging-elevation link-draggable hover-background"
+        :class="draggableClass"
+        :style="draggableStyle"
+    >
+        <icon-component :image="currentItem?.source?.image || ''" />
+    </v-sheet>
 </template>
 
 <style scoped>
 .link-draggable {
-  position: absolute;
-  z-index: 5000;
-  touch-action: none;
+    position: absolute;
+    z-index: 5000;
+    touch-action: none;
 }
 </style>

--- a/site/src/components/main-panel/link-draggable.vue
+++ b/site/src/components/main-panel/link-draggable.vue
@@ -28,11 +28,13 @@ const emit = defineEmits<{
   (
     e: "output-dropped-empty",
     productName: string,
+    sourceItemId: string,
     screenPosition: ReadonlyPointType
   ): void;
   (
     e: "input-dropped-empty",
     productName: string,
+    sourceItemId: string,
     screenPosition: ReadonlyPointType
   ): void;
 }>();
@@ -281,14 +283,16 @@ useEventHook(hooks.notifyDrop, (param) => {
   } else if (sourceItem && !sourceItem.isInput) {
     // Output dropped in empty space - emit event to show consuming recipes
     const productName = sourceItem.name;
-    if (productName) {
-      emit("output-dropped-empty", productName, param.screenRect);
+    const sourceItemId = sourceItem.ownerItem?.key;
+    if (productName && sourceItemId) {
+      emit("output-dropped-empty", productName, sourceItemId, param.screenRect);
     }
   } else if (sourceItem && sourceItem.isInput) {
     // Input dropped in empty space - emit event to show producing recipes
     const productName = sourceItem.name;
-    if (productName) {
-      emit("input-dropped-empty", productName, param.screenRect);
+    const sourceItemId = sourceItem.ownerItem?.key;
+    if (productName && sourceItemId) {
+      emit("input-dropped-empty", productName, sourceItemId, param.screenRect);
     }
   }
   clearHoveringItem();

--- a/site/src/components/main-panel/link-draggable.vue
+++ b/site/src/components/main-panel/link-draggable.vue
@@ -3,23 +3,40 @@ Author: Alexey Usov (dax@xdax.ru, https://github.com/doubleaxe)
 Please don't remove this comment if you use unmodified file
 -->
 <script setup lang="ts">
-import {unref, computed, reactive, toRaw, ref, watch, nextTick} from 'vue';
+import { unref, computed, reactive, toRaw, ref, watch, nextTick } from "vue";
 import {
-    injectBlueprintModel,
-    type BlueprintItemModel,
-    type RecipeIOModel,
-} from '@/scripts/model/store';
-import {Rect, type ReadonlyPointType} from '@/scripts/geometry';
-import {BlueprintItemState, type BlueprintItemStateValues} from '@/scripts/types';
-import {screenToClient, SelectedClassType, useLinkDragAndDrop, usePointAndClick, useSharedBlueprintSurface} from '@/composables/drag-helpers';
-import {useEventHook} from '@/composables';
-import {injectSettings} from '@/scripts/settings';
+  injectBlueprintModel,
+  type BlueprintItemModel,
+  type RecipeIOModel,
+} from "@/scripts/model/store";
+import { Rect, type ReadonlyPointType } from "@/scripts/geometry";
+import {
+  BlueprintItemState,
+  type BlueprintItemStateValues,
+} from "@/scripts/types";
+import {
+  screenToClient,
+  SelectedClassType,
+  useLinkDragAndDrop,
+  usePointAndClick,
+  useSharedBlueprintSurface,
+} from "@/composables/drag-helpers";
+import { useEventHook } from "@/composables";
+import { injectSettings } from "@/scripts/settings";
+
+const emit = defineEmits<{
+  (
+    e: "output-dropped-empty",
+    productName: string,
+    screenPosition: ReadonlyPointType
+  ): void;
+}>();
 
 type BetweenSelfIo = {
-    upper?: RecipeIOModel;
-    upperIndex?: number;
-    lower?: RecipeIOModel;
-    lowerIndex?: number;
+  upper?: RecipeIOModel;
+  upperIndex?: number;
+  lower?: RecipeIOModel;
+  lowerIndex?: number;
 };
 
 const blueprintModel = injectBlueprintModel();
@@ -27,251 +44,301 @@ const settings = injectSettings();
 let hoveringItem: BlueprintItemModel | undefined = undefined;
 let hoveringBetweenIo: BetweenSelfIo | undefined = undefined;
 
-const {hooks, isDragging, currentItem, movableElem} = useLinkDragAndDrop();
-const {notifySelected} = usePointAndClick();
-const {boundingRect} = useSharedBlueprintSurface();
+const { hooks, isDragging, currentItem, movableElem } = useLinkDragAndDrop();
+const { notifySelected } = usePointAndClick();
+const { boundingRect } = useSharedBlueprintSurface();
 
-const draggableClass = ref('');
+const draggableClass = ref("");
 const draggableStyle = computed(() => {
-    const _isDragging = unref(isDragging);
-    const _dragRect = unref(currentItem)?.dragging?.rect;
-    //keep far offscreen, so drag-n-drop processor could get width and height
-    if(!_isDragging || !_dragRect) {
-        return {};
-    }
-    return {
-        left: `${_dragRect.x}px`,
-        top: `${_dragRect.y}px`,
-    };
+  const _isDragging = unref(isDragging);
+  const _dragRect = unref(currentItem)?.dragging?.rect;
+  //keep far offscreen, so drag-n-drop processor could get width and height
+  if (!_isDragging || !_dragRect) {
+    return {};
+  }
+  return {
+    left: `${_dragRect.x}px`,
+    top: `${_dragRect.y}px`,
+  };
 });
 
-watch(isDragging, (value) => {
-    if(!value) {
-        draggableClass.value = 'link-draggable-hidden';
+watch(
+  isDragging,
+  (value) => {
+    if (!value) {
+      draggableClass.value = "link-draggable-hidden";
     } else {
-        //this is against flickering, so first position is set, and next icon is shown
-        //otherwise it sometimes jump out of somewhere
-        nextTick(() => {
-            draggableClass.value = '';
-        });
+      //this is against flickering, so first position is set, and next icon is shown
+      //otherwise it sometimes jump out of somewhere
+      nextTick(() => {
+        draggableClass.value = "";
+      });
     }
-}, {immediate: true});
+  },
+  { immediate: true }
+);
 
 function clearHoveringItem() {
-    if(hoveringItem) {
-        hoveringItem.updateLinkState();
-        hoveringItem = undefined;
-    }
+  if (hoveringItem) {
+    hoveringItem.updateLinkState();
+    hoveringItem = undefined;
+  }
 }
 
 function clearHoveringBetweenIo() {
-    if(hoveringBetweenIo) {
-        if(hoveringBetweenIo.lower) {
-            hoveringBetweenIo.lower.setHighlightBorder(0);
-        }
-        if(hoveringBetweenIo.upper) {
-            hoveringBetweenIo.upper.setHighlightBorder(0);
-        }
-        hoveringBetweenIo = undefined;
+  if (hoveringBetweenIo) {
+    if (hoveringBetweenIo.lower) {
+      hoveringBetweenIo.lower.setHighlightBorder(0);
     }
+    if (hoveringBetweenIo.upper) {
+      hoveringBetweenIo.upper.setHighlightBorder(0);
+    }
+    hoveringBetweenIo = undefined;
+  }
 }
 
 type BlueprintItemWithElement = {
-    item: BlueprintItemModel;
-    element: HTMLElement;
+  item: BlueprintItemModel;
+  element: HTMLElement;
 };
 function detectItemFromPoint(screenPoint: ReadonlyPointType) {
-    const elements = document.elementsFromPoint(screenPoint.x, screenPoint.y);
-    let item: Partial<BlueprintItemWithElement> = {};
-    elements.find((element) => {
-        const itemId = element.getAttribute('data-item-id');
-        if(itemId) {
-            const blueprintItem = blueprintModel.itemByKey(itemId);
-            if(blueprintItem) {
-                item = {item: blueprintItem, element: element as HTMLElement};
-                return true;
-            }
-        }
-        return false;
-    });
-    return item;
+  const elements = document.elementsFromPoint(screenPoint.x, screenPoint.y);
+  let item: Partial<BlueprintItemWithElement> = {};
+  elements.find((element) => {
+    const itemId = element.getAttribute("data-item-id");
+    if (itemId) {
+      const blueprintItem = blueprintModel.itemByKey(itemId);
+      if (blueprintItem) {
+        item = { item: blueprintItem, element: element as HTMLElement };
+        return true;
+      }
+    }
+    return false;
+  });
+  return item;
 }
 
 type SourceItemWithElement = {
-    sourceItem: BlueprintItemModel;
-    sourceElem: HTMLElement;
+  sourceItem: BlueprintItemModel;
+  sourceElem: HTMLElement;
 };
-function getSelfLinkNeighbourIo({sourceItem, sourceElem}: SourceItemWithElement, sourceIo: RecipeIOModel, screenPoint: ReadonlyPointType) {
-    const clientPoint = screenToClient(sourceElem, Rect.assign(screenPoint), settings.scale).offsetBy(sourceItem.rect);
-    //check if mouse point is between io rects
-    const neighbourIo = (sourceIo.isInput ?
-        sourceItem.selectedRecipe?.visibleInput() :
-        sourceItem.selectedRecipe?.visibleOutput()) || [];
+function getSelfLinkNeighbourIo(
+  { sourceItem, sourceElem }: SourceItemWithElement,
+  sourceIo: RecipeIOModel,
+  screenPoint: ReadonlyPointType
+) {
+  const clientPoint = screenToClient(
+    sourceElem,
+    Rect.assign(screenPoint),
+    settings.scale
+  ).offsetBy(sourceItem.rect);
+  //check if mouse point is between io rects
+  const neighbourIo =
+    (sourceIo.isInput
+      ? sourceItem.selectedRecipe?.visibleInput()
+      : sourceItem.selectedRecipe?.visibleOutput()) || [];
 
-    const betweenIo: BetweenSelfIo = {};
-    for(let i = 0; i < neighbourIo.length; i++) {
-        const io1 = neighbourIo[i];
-        const midPoint1 = io1.rect.middleRectPoint();
-        //if midpoint is above client rect, then mouse is in between this io and previous io
-        if(midPoint1.y > clientPoint.y) {
-            betweenIo.lowerIndex = i;
-            betweenIo.lower = io1;
-            if(i > 0) {
-                betweenIo.upperIndex = i - 1;
-                betweenIo.upper = neighbourIo[betweenIo.upperIndex];
-            }
-            break;
-        }
-    }
-    //if lower is found, then mouse is below last io
-    if(!betweenIo.lower) {
-        betweenIo.upperIndex = neighbourIo.length - 1;
+  const betweenIo: BetweenSelfIo = {};
+  for (let i = 0; i < neighbourIo.length; i++) {
+    const io1 = neighbourIo[i];
+    const midPoint1 = io1.rect.middleRectPoint();
+    //if midpoint is above client rect, then mouse is in between this io and previous io
+    if (midPoint1.y > clientPoint.y) {
+      betweenIo.lowerIndex = i;
+      betweenIo.lower = io1;
+      if (i > 0) {
+        betweenIo.upperIndex = i - 1;
         betweenIo.upper = neighbourIo[betweenIo.upperIndex];
+      }
+      break;
     }
-    return betweenIo;
+  }
+  //if lower is found, then mouse is below last io
+  if (!betweenIo.lower) {
+    betweenIo.upperIndex = neighbourIo.length - 1;
+    betweenIo.upper = neighbourIo[betweenIo.upperIndex];
+  }
+  return betweenIo;
 }
 
 function processSelfLinkInsertionPoint(betweenIo: BetweenSelfIo) {
-    if(!betweenIo.upper && !betweenIo.lower) {
-        //impossible, maybe exactly midpoint
-        clearHoveringBetweenIo();
-        return;
-    }
-    if((betweenIo.lowerIndex === hoveringBetweenIo?.lowerIndex) && (betweenIo.upperIndex === hoveringBetweenIo?.upperIndex)) {
-        return;
-    }
+  if (!betweenIo.upper && !betweenIo.lower) {
+    //impossible, maybe exactly midpoint
     clearHoveringBetweenIo();
-    //on lower io highlight upper border
-    betweenIo.lower?.setHighlightBorder(1);
-    betweenIo.upper?.setHighlightBorder(-1);
-    hoveringBetweenIo = betweenIo;
+    return;
+  }
+  if (
+    betweenIo.lowerIndex === hoveringBetweenIo?.lowerIndex &&
+    betweenIo.upperIndex === hoveringBetweenIo?.upperIndex
+  ) {
+    return;
+  }
+  clearHoveringBetweenIo();
+  //on lower io highlight upper border
+  betweenIo.lower?.setHighlightBorder(1);
+  betweenIo.upper?.setHighlightBorder(-1);
+  hoveringBetweenIo = betweenIo;
 }
 
-function processOtherFactoryLink(sourceIo: RecipeIOModel, draggingIo: RecipeIOModel, targetItem: BlueprintItemModel) {
-    hoveringItem = targetItem;
-    hoveringItem.updateLinkState(sourceIo);
-    draggingIo.setFlipped(targetItem.isFlipped);
+function processOtherFactoryLink(
+  sourceIo: RecipeIOModel,
+  draggingIo: RecipeIOModel,
+  targetItem: BlueprintItemModel
+) {
+  hoveringItem = targetItem;
+  hoveringItem.updateLinkState(sourceIo);
+  draggingIo.setFlipped(targetItem.isFlipped);
 }
 
-function processTargetItem(sourceItem: RecipeIOModel, draggingItem: RecipeIOModel, screenPoint: ReadonlyPointType) {
-    const {item, element} = detectItemFromPoint(screenPoint);
-    if(!item || !element) {
-        clearHoveringItem();
-        clearHoveringBetweenIo();
-        return;
-    }
-    if(toRaw(item) === toRaw(sourceItem?.ownerItem)) {
-        clearHoveringItem();
-        const betweenIo = getSelfLinkNeighbourIo({sourceItem: item, sourceElem: element}, sourceItem, screenPoint);
-        processSelfLinkInsertionPoint(betweenIo);
-        return;
-    }
-    if(toRaw(item) === toRaw(hoveringItem)) {
-        return;
-    }
+function processTargetItem(
+  sourceItem: RecipeIOModel,
+  draggingItem: RecipeIOModel,
+  screenPoint: ReadonlyPointType
+) {
+  const { item, element } = detectItemFromPoint(screenPoint);
+  if (!item || !element) {
     clearHoveringItem();
     clearHoveringBetweenIo();
-    processOtherFactoryLink(sourceItem, draggingItem, item);
+    return;
+  }
+  if (toRaw(item) === toRaw(sourceItem?.ownerItem)) {
+    clearHoveringItem();
+    const betweenIo = getSelfLinkNeighbourIo(
+      { sourceItem: item, sourceElem: element },
+      sourceItem,
+      screenPoint
+    );
+    processSelfLinkInsertionPoint(betweenIo);
+    return;
+  }
+  if (toRaw(item) === toRaw(hoveringItem)) {
+    return;
+  }
+  clearHoveringItem();
+  clearHoveringBetweenIo();
+  processOtherFactoryLink(sourceItem, draggingItem, item);
 }
 
 function processSwapIo(betweenIo: BetweenSelfIo, sourceIo: RecipeIOModel) {
-    if(!betweenIo.upper && !betweenIo.lower) {
-        return false;
-    }
-    if((toRaw(betweenIo.lower) === toRaw(sourceIo)) || (toRaw(betweenIo.upper) === toRaw(sourceIo))) {
-        return false;
-    }
-    const selectedRecipe = sourceIo.ownerItem?.selectedRecipe;
-    if(!selectedRecipe) {
-        return false;
-    }
-    selectedRecipe.swapIo(sourceIo.key, [betweenIo.upperIndex, betweenIo.lowerIndex]);
-    return true;
+  if (!betweenIo.upper && !betweenIo.lower) {
+    return false;
+  }
+  if (
+    toRaw(betweenIo.lower) === toRaw(sourceIo) ||
+    toRaw(betweenIo.upper) === toRaw(sourceIo)
+  ) {
+    return false;
+  }
+  const selectedRecipe = sourceIo.ownerItem?.selectedRecipe;
+  if (!selectedRecipe) {
+    return false;
+  }
+  selectedRecipe.swapIo(sourceIo.key, [
+    betweenIo.upperIndex,
+    betweenIo.lowerIndex,
+  ]);
+  return true;
 }
 
-function processLink(sourceItem: RecipeIOModel, _hoveringItem: BlueprintItemModel, hoveringState: BlueprintItemStateValues) {
-    if(hoveringState === BlueprintItemState.CanLinkTarget) {
-        _hoveringItem.createLink(sourceItem);
-        return true;
-    } else if(hoveringState === BlueprintItemState.CanLinkWithRecipeChange) {
-        const recipe = _hoveringItem.possibleRecipeForIo(sourceItem);
-        if(recipe) {
-            _hoveringItem.selectRecipe(recipe);
-            _hoveringItem.createLink(sourceItem);
-        }
-        return true;
+function processLink(
+  sourceItem: RecipeIOModel,
+  _hoveringItem: BlueprintItemModel,
+  hoveringState: BlueprintItemStateValues
+) {
+  if (hoveringState === BlueprintItemState.CanLinkTarget) {
+    _hoveringItem.createLink(sourceItem);
+    return true;
+  } else if (hoveringState === BlueprintItemState.CanLinkWithRecipeChange) {
+    const recipe = _hoveringItem.possibleRecipeForIo(sourceItem);
+    if (recipe) {
+      _hoveringItem.selectRecipe(recipe);
+      _hoveringItem.createLink(sourceItem);
     }
-    return false;
+    return true;
+  }
+  return false;
 }
 
 useEventHook(hooks.notifyStart, (param) => {
-    const item = param.item;
-    const {link, target} = reactive(item.source.createTempLink());
-    target.setFlipped(item.source.isFlipped);
-    item.link = link;
-    item.dragging = target;
+  const item = param.item;
+  const { link, target } = reactive(item.source.createTempLink());
+  target.setFlipped(item.source.isFlipped);
+  item.link = link;
+  item.dragging = target;
 });
 
 useEventHook(hooks.notifyDrop, (param) => {
-    const sourceItem = param.item.source;
-    if(sourceItem && hoveringItem) {
-        processLink(sourceItem, hoveringItem, hoveringItem.state);
-    } else if(sourceItem && hoveringBetweenIo) {
-        processSwapIo(hoveringBetweenIo, sourceItem);
+  const sourceItem = param.item.source;
+  if (sourceItem && hoveringItem) {
+    processLink(sourceItem, hoveringItem, hoveringItem.state);
+  } else if (sourceItem && hoveringBetweenIo) {
+    processSwapIo(hoveringBetweenIo, sourceItem);
+  } else if (sourceItem && !sourceItem.isInput) {
+    // Output dropped in empty space - emit event to show recipe suggestions
+    const productName = sourceItem.name;
+    if (productName) {
+      emit("output-dropped-empty", productName, param.screenRect);
     }
-    clearHoveringItem();
-    clearHoveringBetweenIo();
-    blueprintModel.clearTempLink();
+  }
+  clearHoveringItem();
+  clearHoveringBetweenIo();
+  blueprintModel.clearTempLink();
 });
 
 useEventHook(hooks.notifyCancel, () => blueprintModel.clearTempLink());
 
 useEventHook(hooks.notifyMove, (param) => {
-    const draggingItem = param.item.dragging;
-    if(draggingItem) {
-        draggingItem.setRect(param.clientRect.limit(unref(boundingRect)));
-        processTargetItem(param.item.source, draggingItem, param.screenRect);
-    }
+  const draggingItem = param.item.dragging;
+  if (draggingItem) {
+    draggingItem.setRect(param.clientRect.limit(unref(boundingRect)));
+    processTargetItem(param.item.source, draggingItem, param.screenRect);
+  }
 });
 
 useEventHook(notifySelected, (param) => {
-    if(param.item.clazz != SelectedClassType.RecipeIOModel) {
-        return;
+  if (param.item.clazz != SelectedClassType.RecipeIOModel) {
+    return;
+  }
+  const sourceItem = param.item.item as RecipeIOModel;
+  const { item: _hoveringItem, element } = detectItemFromPoint(
+    param.screenPosition
+  );
+  if (!_hoveringItem || !element) {
+    return;
+  }
+  if (toRaw(_hoveringItem) === toRaw(sourceItem?.ownerItem)) {
+    const betweenIo = getSelfLinkNeighbourIo(
+      { sourceItem: _hoveringItem, sourceElem: element },
+      sourceItem,
+      param.screenPosition
+    );
+    if (processSwapIo(betweenIo, sourceItem)) {
+      param.wasHandled();
     }
-    const sourceItem = param.item.item as RecipeIOModel;
-    const {item: _hoveringItem, element} = detectItemFromPoint(param.screenPosition);
-    if(!_hoveringItem || !element) {
-        return;
-    }
-    if(toRaw(_hoveringItem) === toRaw(sourceItem?.ownerItem)) {
-        const betweenIo = getSelfLinkNeighbourIo({sourceItem: _hoveringItem, sourceElem: element}, sourceItem, param.screenPosition);
-        if(processSwapIo(betweenIo, sourceItem)) {
-            param.wasHandled();
-        }
-        return;
-    }
-    const linkState = _hoveringItem.calculateLinkState(sourceItem);
-    if(processLink(sourceItem, _hoveringItem, linkState)) {
-        param.wasHandled();
-    }
+    return;
+  }
+  const linkState = _hoveringItem.calculateLinkState(sourceItem);
+  if (processLink(sourceItem, _hoveringItem, linkState)) {
+    param.wasHandled();
+  }
 });
 </script>
 
 <template>
-    <v-sheet
-        ref="movableElem"
-        class="rounded dragging-elevation link-draggable hover-background"
-        :class="draggableClass"
-        :style="draggableStyle"
-    >
-        <icon-component :image="currentItem?.source?.image || ''" />
-    </v-sheet>
+  <v-sheet
+    ref="movableElem"
+    class="rounded dragging-elevation link-draggable hover-background"
+    :class="draggableClass"
+    :style="draggableStyle"
+  >
+    <icon-component :image="currentItem?.source?.image || ''" />
+  </v-sheet>
 </template>
 
 <style scoped>
 .link-draggable {
-    position: absolute;
-    z-index: 5000;
-    touch-action: none;
+  position: absolute;
+  z-index: 5000;
+  touch-action: none;
 }
 </style>

--- a/site/src/components/main-panel/link-draggable.vue
+++ b/site/src/components/main-panel/link-draggable.vue
@@ -30,6 +30,11 @@ const emit = defineEmits<{
     productName: string,
     screenPosition: ReadonlyPointType
   ): void;
+  (
+    e: "input-dropped-empty",
+    productName: string,
+    screenPosition: ReadonlyPointType
+  ): void;
 }>();
 
 type BetweenSelfIo = {
@@ -274,10 +279,16 @@ useEventHook(hooks.notifyDrop, (param) => {
   } else if (sourceItem && hoveringBetweenIo) {
     processSwapIo(hoveringBetweenIo, sourceItem);
   } else if (sourceItem && !sourceItem.isInput) {
-    // Output dropped in empty space - emit event to show recipe suggestions
+    // Output dropped in empty space - emit event to show consuming recipes
     const productName = sourceItem.name;
     if (productName) {
       emit("output-dropped-empty", productName, param.screenRect);
+    }
+  } else if (sourceItem && sourceItem.isInput) {
+    // Input dropped in empty space - emit event to show producing recipes
+    const productName = sourceItem.name;
+    if (productName) {
+      emit("input-dropped-empty", productName, param.screenRect);
     }
   }
   clearHoveringItem();

--- a/site/src/components/main-panel/recipe-suggestion-menu.vue
+++ b/site/src/components/main-panel/recipe-suggestion-menu.vue
@@ -4,328 +4,328 @@ Based on recipes-menu.vue by Alexey Usov (dax@xdax.ru, https://github.com/double
 Feature: Show recipe suggestions when output is dropped in empty space
 -->
 <script setup lang="ts">
-import { GameRecipeIOFlags } from "#types/constants";
-import type { GameItem, GameRecipe, GameRecipeIO } from "#types/game-data";
-import { injectGameData } from "@/scripts/data";
-import { mdiArrowRight, mdiClose } from "@mdi/js";
-import { useDebounceFn } from "@vueuse/core";
-import { computed, nextTick, ref, unref, watch } from "vue";
-import type { ReadonlyPointType } from "@/scripts/geometry";
+import {GameRecipeIOFlags} from '#types/constants';
+import type {GameItem, GameRecipe, GameRecipeIO} from '#types/game-data';
+import {injectGameData} from '@/scripts/data';
+import {mdiArrowRight, mdiClose} from '@mdi/js';
+import {useDebounceFn} from '@vueuse/core';
+import {computed, nextTick, ref, unref, watch} from 'vue';
+import type {ReadonlyPointType} from '@/scripts/geometry';
 
 const gameData = injectGameData();
 
 interface RecipeWithFactory {
-  factory: GameItem;
-  recipe: GameRecipe;
+    factory: GameItem;
+    recipe: GameRecipe;
 }
 
 const active = ref<boolean>(false);
-const search = ref<string>("");
+const search = ref<string>('');
 const allRecipes = ref<RecipeWithFactory[]>([]);
 const recipes = ref<RecipeWithFactory[]>([]);
-const menuPosition = ref<{ x: number; y: number }>({ x: 0, y: 0 });
-const sourceProductName = ref<string>("");
-const sourceItemId = ref<string>("");
-const dropScreenPosition = ref<ReadonlyPointType>({ x: 0, y: 0 });
-const menuMode = ref<"consuming" | "producing">("consuming");
+const menuPosition = ref<{x: number; y: number}>({x: 0, y: 0});
+const sourceProductName = ref<string>('');
+const sourceItemId = ref<string>('');
+const dropScreenPosition = ref<ReadonlyPointType>({x: 0, y: 0});
+const menuMode = ref<'consuming' | 'producing'>('consuming');
 
 const pageSize = 10;
 const page = ref(1);
 const maxPages = computed(() => Math.ceil(unref(allRecipes).length / pageSize));
 const pages = computed(() => Math.ceil(unref(recipes).length / pageSize) || 1);
 const currentPage = computed(() => {
-  const start = (unref(page) - 1) * pageSize;
-  return unref(recipes).slice(start, start + pageSize);
+    const start = (unref(page) - 1) * pageSize;
+    return unref(recipes).slice(start, start + pageSize);
 });
 
 // Compute menu title based on mode
 const menuTitle = computed(() => {
-  return unref(menuMode) === "consuming"
-    ? "Add consuming factory"
-    : "Add producing factory";
+    return unref(menuMode) === 'consuming'
+        ? 'Add consuming factory'
+        : 'Add producing factory';
 });
 
 // Compute menu style based on position
 const menuStyle = computed(() => {
-  const pos = unref(menuPosition);
-  return {
-    left: `${pos.x}px`,
-    top: `${pos.y}px`,
-  };
+    const pos = unref(menuPosition);
+    return {
+        left: `${pos.x}px`,
+        top: `${pos.y}px`,
+    };
 });
 
 const emit = defineEmits<{
-  (
-    e: "recipe-selected",
-    factory: GameItem,
-    recipe: GameRecipe,
-    productName: string,
-    sourceItemId: string,
-    screenPosition: ReadonlyPointType,
-    mode: "consuming" | "producing"
-  ): void;
+    (
+        e: 'recipe-selected',
+        factory: GameItem,
+        recipe: GameRecipe,
+        productName: string,
+        sourceItemId: string,
+        screenPosition: ReadonlyPointType,
+        mode: 'consuming' | 'producing'
+    ): void;
 }>();
 
 function findRecipesUsingInput(itemName: string): RecipeWithFactory[] {
-  const results: RecipeWithFactory[] = [];
-  for (const factory of gameData.gameFactoriesArray) {
-    const dict = factory.recipeDictionary;
-    if (!dict) continue;
-    const recipeNames = dict.recipesByInputMap.get(itemName);
-    if (recipeNames) {
-      for (const recipeName of recipeNames) {
-        const recipe = dict.recipesMap.get(recipeName);
-        if (recipe) {
-          results.push({ factory, recipe });
+    const results: RecipeWithFactory[] = [];
+    for(const factory of gameData.gameFactoriesArray) {
+        const dict = factory.recipeDictionary;
+        if(!dict) continue;
+        const recipeNames = dict.recipesByInputMap.get(itemName);
+        if(recipeNames) {
+            for(const recipeName of recipeNames) {
+                const recipe = dict.recipesMap.get(recipeName);
+                if(recipe) {
+                    results.push({factory, recipe});
+                }
+            }
         }
-      }
     }
-  }
-  return results;
+    return results;
 }
 
 function findRecipesProducingOutput(itemName: string): RecipeWithFactory[] {
-  const results: RecipeWithFactory[] = [];
-  for (const factory of gameData.gameFactoriesArray) {
-    const dict = factory.recipeDictionary;
-    if (!dict) continue;
-    const recipeNames = dict.recipesByOutputMap.get(itemName);
-    if (recipeNames) {
-      for (const recipeName of recipeNames) {
-        const recipe = dict.recipesMap.get(recipeName);
-        if (recipe) {
-          results.push({ factory, recipe });
+    const results: RecipeWithFactory[] = [];
+    for(const factory of gameData.gameFactoriesArray) {
+        const dict = factory.recipeDictionary;
+        if(!dict) continue;
+        const recipeNames = dict.recipesByOutputMap.get(itemName);
+        if(recipeNames) {
+            for(const recipeName of recipeNames) {
+                const recipe = dict.recipesMap.get(recipeName);
+                if(recipe) {
+                    results.push({factory, recipe});
+                }
+            }
         }
-      }
     }
-  }
-  return results;
+    return results;
 }
 
 function activate(
-  productName: string,
-  _sourceItemId: string,
-  screenPosition: ReadonlyPointType,
-  mode: "consuming" | "producing" = "consuming"
+    productName: string,
+    _sourceItemId: string,
+    screenPosition: ReadonlyPointType,
+    mode: 'consuming' | 'producing' = 'consuming',
 ) {
-  const foundRecipes =
-    mode === "consuming"
-      ? findRecipesUsingInput(productName)
-      : findRecipesProducingOutput(productName);
+    const foundRecipes =
+    mode === 'consuming'
+        ? findRecipesUsingInput(productName)
+        : findRecipesProducingOutput(productName);
 
-  if (foundRecipes.length === 0) {
-    return; // No recipes found, don't show menu
-  }
+    if(foundRecipes.length === 0) {
+        return; // No recipes found, don't show menu
+    }
 
-  menuMode.value = mode;
-  sourceProductName.value = productName;
-  sourceItemId.value = _sourceItemId;
-  dropScreenPosition.value = screenPosition;
-  allRecipes.value = foundRecipes;
-  recipes.value = foundRecipes;
-  page.value = 1;
-  search.value = "";
+    menuMode.value = mode;
+    sourceProductName.value = productName;
+    sourceItemId.value = _sourceItemId;
+    dropScreenPosition.value = screenPosition;
+    allRecipes.value = foundRecipes;
+    recipes.value = foundRecipes;
+    page.value = 1;
+    search.value = '';
 
-  // Position menu at drop location
-  menuPosition.value = {
-    x: screenPosition.x,
-    y: screenPosition.y,
-  };
+    // Position menu at drop location
+    menuPosition.value = {
+        x: screenPosition.x,
+        y: screenPosition.y,
+    };
 
-  nextTick(() => {
-    active.value = true;
-  });
+    nextTick(() => {
+        active.value = true;
+    });
 }
 
 function recipeSelected(item: RecipeWithFactory) {
-  active.value = false;
-  emit(
-    "recipe-selected",
-    item.factory,
-    item.recipe,
-    unref(sourceProductName),
-    unref(sourceItemId),
-    unref(dropScreenPosition),
-    unref(menuMode)
-  );
+    active.value = false;
+    emit(
+        'recipe-selected',
+        item.factory,
+        item.recipe,
+        unref(sourceProductName),
+        unref(sourceItemId),
+        unref(dropScreenPosition),
+        unref(menuMode),
+    );
 }
 
 function closeMenu() {
-  active.value = false;
+    active.value = false;
 }
 
 const applyFilter = useDebounceFn(
-  () => {
-    let val = unref(search);
-    val = val && val.trim();
-    if (!val) {
-      recipes.value = unref(allRecipes);
-      page.value = 1;
-      return;
-    }
-    const searchText = val
+    () => {
+        let val = unref(search);
+        val = val && val.trim();
+        if(!val) {
+            recipes.value = unref(allRecipes);
+            page.value = 1;
+            return;
+        }
+        const searchText = val
       .toLowerCase()
       .split(/\s+/)
       .map((s) => s.trim());
-    recipes.value = unref(allRecipes).filter((item) =>
-      searchText.every(
-        (l) =>
-          !l ||
+        recipes.value = unref(allRecipes).filter((item) =>
+            searchText.every(
+                (l) =>
+                    !l ||
           item.recipe.input.some(
-            (io) => io.product.lowerLabel.indexOf(l) > -1
+              (io) => io.product.lowerLabel.indexOf(l) > -1,
           ) ||
           item.recipe.output.some(
-            (io) => io.product.lowerLabel.indexOf(l) > -1
+              (io) => io.product.lowerLabel.indexOf(l) > -1,
           ) ||
-          item.factory.lowerLabel.indexOf(l) > -1
-      )
-    );
-    if (unref(page) > unref(pages)) {
-      page.value = unref(pages);
-    }
-  },
-  400,
-  { maxWait: 1000 }
+          item.factory.lowerLabel.indexOf(l) > -1,
+            ),
+        );
+        if(unref(page) > unref(pages)) {
+            page.value = unref(pages);
+        }
+    },
+    400,
+    {maxWait: 1000},
 );
 
 function filterShownRecipeIo(io: GameRecipeIO[]) {
-  return io.filter((i) => !(i.flags & GameRecipeIOFlags.HideInMenu));
+    return io.filter((i) => !(i.flags & GameRecipeIOFlags.HideInMenu));
 }
 
 watch(search, (value, oldValue) => {
-  if (oldValue != value) {
-    applyFilter();
-  }
+    if(oldValue != value) {
+        applyFilter();
+    }
 });
 
 defineExpose({
-  activate,
+    activate,
 });
 </script>
 
 <template>
-  <Teleport to="body">
-    <!-- Backdrop for click outside -->
-    <div v-if="active" class="recipe-suggestion-backdrop" @click="closeMenu" />
-    <!-- Menu positioned at drop location -->
-    <div v-if="active" class="recipe-suggestion-menu" :style="menuStyle">
-      <v-card elevation="8" class="menu-card">
-        <v-card-title class="menu-header">
-          <span>{{ menuTitle }}</span>
-          <v-btn
-            size="small"
-            variant="text"
-            :icon="mdiClose"
-            @click="closeMenu"
-          />
-        </v-card-title>
-        <v-divider />
-        <v-list density="compact" class="menu-list">
-          <v-list-item v-if="maxPages > 1" class="minwidth">
-            <v-text-field
-              v-model="search"
-              density="compact"
-              placeholder="Search recipes..."
-              hide-details
-              clearable
-              @click.stop
-            />
-          </v-list-item>
-          <optimized-tooltip>
-            <v-list-item
-              v-for="(item, index) in currentPage"
-              :key="index"
-              @click="recipeSelected(item)"
-            >
-              <v-list-item-title>
-                <div class="io-menu-item">
-                  <icon-component
-                    :image="item.factory.image"
-                    :data-tooltip="item.factory.label"
-                  />
-                  <span class="factory-label">{{ item.factory.label }}</span>
-                </div>
-                <div class="io-menu-item recipe-row">
-                  <recipes-menu-io
-                    :ioarray="filterShownRecipeIo(item.recipe.input)"
-                  />
-                  <v-icon class="d-block" :icon="mdiArrowRight" />
-                  <recipes-menu-io
-                    :ioarray="filterShownRecipeIo(item.recipe.output)"
-                  />
-                </div>
-              </v-list-item-title>
-            </v-list-item>
-          </optimized-tooltip>
-          <v-list-item v-if="maxPages > 1" class="minwidth">
-            <v-pagination
-              v-model="page"
-              density="compact"
-              :length="pages"
-              :total-visible="4"
-              @click.stop
-            />
-          </v-list-item>
-        </v-list>
-      </v-card>
-    </div>
-  </Teleport>
+    <Teleport to="body">
+        <!-- Backdrop for click outside -->
+        <div v-if="active" class="recipe-suggestion-backdrop" @click="closeMenu" />
+        <!-- Menu positioned at drop location -->
+        <div v-if="active" class="recipe-suggestion-menu" :style="menuStyle">
+            <v-card elevation="8" class="menu-card">
+                <v-card-title class="menu-header">
+                    <span>{{ menuTitle }}</span>
+                    <v-btn
+                        size="small"
+                        variant="text"
+                        :icon="mdiClose"
+                        @click="closeMenu"
+                    />
+                </v-card-title>
+                <v-divider />
+                <v-list density="compact" class="menu-list">
+                    <v-list-item v-if="maxPages > 1" class="minwidth">
+                        <v-text-field
+                            v-model="search"
+                            density="compact"
+                            placeholder="Search recipes..."
+                            hide-details
+                            clearable
+                            @click.stop
+                        />
+                    </v-list-item>
+                    <optimized-tooltip>
+                        <v-list-item
+                            v-for="(item, index) in currentPage"
+                            :key="index"
+                            @click="recipeSelected(item)"
+                        >
+                            <v-list-item-title>
+                                <div class="io-menu-item">
+                                    <icon-component
+                                        :image="item.factory.image"
+                                        :data-tooltip="item.factory.label"
+                                    />
+                                    <span class="factory-label">{{ item.factory.label }}</span>
+                                </div>
+                                <div class="io-menu-item recipe-row">
+                                    <recipes-menu-io
+                                        :ioarray="filterShownRecipeIo(item.recipe.input)"
+                                    />
+                                    <v-icon class="d-block" :icon="mdiArrowRight" />
+                                    <recipes-menu-io
+                                        :ioarray="filterShownRecipeIo(item.recipe.output)"
+                                    />
+                                </div>
+                            </v-list-item-title>
+                        </v-list-item>
+                    </optimized-tooltip>
+                    <v-list-item v-if="maxPages > 1" class="minwidth">
+                        <v-pagination
+                            v-model="page"
+                            density="compact"
+                            :length="pages"
+                            :total-visible="4"
+                            @click.stop
+                        />
+                    </v-list-item>
+                </v-list>
+            </v-card>
+        </div>
+    </Teleport>
 </template>
 
 <style scoped>
 .recipe-suggestion-backdrop {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  z-index: 9998;
-  background: transparent;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 9998;
+    background: transparent;
 }
 
 .recipe-suggestion-menu {
-  position: fixed;
-  z-index: 9999;
-  max-height: 80vh;
-  overflow: visible;
+    position: fixed;
+    z-index: 9999;
+    max-height: 80vh;
+    overflow: visible;
 }
 
 .menu-card {
-  min-width: 280px;
-  max-width: 400px;
-  max-height: 70vh;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
+    min-width: 280px;
+    max-width: 400px;
+    max-height: 70vh;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
 }
 
 .menu-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 8px 12px;
-  font-size: 0.875rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 12px;
+    font-size: 0.875rem;
 }
 
 .menu-list {
-  overflow-y: auto;
-  flex: 1;
+    overflow-y: auto;
+    flex: 1;
 }
 
 .io-menu-item {
-  display: flex;
-  align-items: center;
+    display: flex;
+    align-items: center;
 }
 .factory-label {
-  margin-left: 0.5rem;
-  font-weight: 500;
+    margin-left: 0.5rem;
+    font-weight: 500;
 }
 .recipe-row {
-  margin-top: 0.25rem;
-  padding-left: 1.5rem;
-  opacity: 0.8;
+    margin-top: 0.25rem;
+    padding-left: 1.5rem;
+    opacity: 0.8;
 }
 .minwidth {
-  min-width: 15rem;
+    min-width: 15rem;
 }
 </style>

--- a/site/src/components/main-panel/recipe-suggestion-menu.vue
+++ b/site/src/components/main-panel/recipe-suggestion-menu.vue
@@ -25,6 +25,7 @@ const allRecipes = ref<RecipeWithFactory[]>([]);
 const recipes = ref<RecipeWithFactory[]>([]);
 const menuPosition = ref<{ x: number; y: number }>({ x: 0, y: 0 });
 const sourceProductName = ref<string>("");
+const sourceItemId = ref<string>("");
 const dropScreenPosition = ref<ReadonlyPointType>({ x: 0, y: 0 });
 const menuMode = ref<"consuming" | "producing">("consuming");
 
@@ -59,6 +60,7 @@ const emit = defineEmits<{
     factory: GameItem,
     recipe: GameRecipe,
     productName: string,
+    sourceItemId: string,
     screenPosition: ReadonlyPointType,
     mode: "consuming" | "producing"
   ): void;
@@ -102,6 +104,7 @@ function findRecipesProducingOutput(itemName: string): RecipeWithFactory[] {
 
 function activate(
   productName: string,
+  _sourceItemId: string,
   screenPosition: ReadonlyPointType,
   mode: "consuming" | "producing" = "consuming"
 ) {
@@ -116,6 +119,7 @@ function activate(
 
   menuMode.value = mode;
   sourceProductName.value = productName;
+  sourceItemId.value = _sourceItemId;
   dropScreenPosition.value = screenPosition;
   allRecipes.value = foundRecipes;
   recipes.value = foundRecipes;
@@ -140,6 +144,7 @@ function recipeSelected(item: RecipeWithFactory) {
     item.factory,
     item.recipe,
     unref(sourceProductName),
+    unref(sourceItemId),
     unref(dropScreenPosition),
     unref(menuMode)
   );

--- a/site/src/components/main-panel/recipe-suggestion-menu.vue
+++ b/site/src/components/main-panel/recipe-suggestion-menu.vue
@@ -28,6 +28,7 @@ const menuStyle = ref<{ left: string; top: string }>({
   top: "0px",
 });
 const sourceProductName = ref<string>("");
+const dropScreenPosition = ref<ReadonlyPointType>({ x: 0, y: 0 });
 
 const pageSize = 10;
 const page = ref(1);
@@ -43,7 +44,8 @@ const emit = defineEmits<{
     e: "recipe-selected",
     factory: GameItem,
     recipe: GameRecipe,
-    productName: string
+    productName: string,
+    screenPosition: ReadonlyPointType
   ): void;
 }>();
 
@@ -72,6 +74,7 @@ function activate(productName: string, screenPosition: ReadonlyPointType) {
   }
 
   sourceProductName.value = productName;
+  dropScreenPosition.value = screenPosition;
   allRecipes.value = foundRecipes;
   recipes.value = foundRecipes;
   page.value = 1;
@@ -90,7 +93,13 @@ function activate(productName: string, screenPosition: ReadonlyPointType) {
 
 function recipeSelected(item: RecipeWithFactory) {
   active.value = false;
-  emit("recipe-selected", item.factory, item.recipe, unref(sourceProductName));
+  emit(
+    "recipe-selected",
+    item.factory,
+    item.recipe,
+    unref(sourceProductName),
+    unref(dropScreenPosition)
+  );
 }
 
 function closeMenu() {

--- a/site/src/components/main-panel/recipe-suggestion-menu.vue
+++ b/site/src/components/main-panel/recipe-suggestion-menu.vue
@@ -1,0 +1,234 @@
+<!--
+Author: Cherecho (GitHub: @Cherecho)
+Based on recipes-menu.vue by Alexey Usov (dax@xdax.ru, https://github.com/doubleaxe)
+Feature: Show recipe suggestions when output is dropped in empty space
+-->
+<script setup lang="ts">
+import { GameRecipeIOFlags } from "#types/constants";
+import type { GameItem, GameRecipe, GameRecipeIO } from "#types/game-data";
+import { injectGameData } from "@/scripts/data";
+import { mdiArrowRight } from "@mdi/js";
+import { useDebounceFn } from "@vueuse/core";
+import { computed, nextTick, ref, unref, watch } from "vue";
+import type { ReadonlyPointType } from "@/scripts/geometry";
+
+const gameData = injectGameData();
+
+interface RecipeWithFactory {
+  factory: GameItem;
+  recipe: GameRecipe;
+}
+
+const active = ref<boolean>(false);
+const search = ref<string>("");
+const allRecipes = ref<RecipeWithFactory[]>([]);
+const recipes = ref<RecipeWithFactory[]>([]);
+const menuStyle = ref<{ left: string; top: string }>({
+  left: "0px",
+  top: "0px",
+});
+const sourceProductName = ref<string>("");
+
+const pageSize = 10;
+const page = ref(1);
+const maxPages = computed(() => Math.ceil(unref(allRecipes).length / pageSize));
+const pages = computed(() => Math.ceil(unref(recipes).length / pageSize) || 1);
+const currentPage = computed(() => {
+  const start = (unref(page) - 1) * pageSize;
+  return unref(recipes).slice(start, start + pageSize);
+});
+
+const emit = defineEmits<{
+  (
+    e: "recipe-selected",
+    factory: GameItem,
+    recipe: GameRecipe,
+    productName: string
+  ): void;
+}>();
+
+function findRecipesUsingInput(itemName: string): RecipeWithFactory[] {
+  const results: RecipeWithFactory[] = [];
+  for (const factory of gameData.gameFactoriesArray) {
+    const dict = factory.recipeDictionary;
+    if (!dict) continue;
+    const recipeNames = dict.recipesByInputMap.get(itemName);
+    if (recipeNames) {
+      for (const recipeName of recipeNames) {
+        const recipe = dict.recipesMap.get(recipeName);
+        if (recipe) {
+          results.push({ factory, recipe });
+        }
+      }
+    }
+  }
+  return results;
+}
+
+function activate(productName: string, screenPosition: ReadonlyPointType) {
+  const foundRecipes = findRecipesUsingInput(productName);
+  if (foundRecipes.length === 0) {
+    return; // No recipes found, don't show menu
+  }
+
+  sourceProductName.value = productName;
+  allRecipes.value = foundRecipes;
+  recipes.value = foundRecipes;
+  page.value = 1;
+  search.value = "";
+
+  // Position menu at drop location
+  menuStyle.value = {
+    left: `${screenPosition.x}px`,
+    top: `${screenPosition.y}px`,
+  };
+
+  nextTick(() => {
+    active.value = true;
+  });
+}
+
+function recipeSelected(item: RecipeWithFactory) {
+  active.value = false;
+  emit("recipe-selected", item.factory, item.recipe, unref(sourceProductName));
+}
+
+function closeMenu() {
+  active.value = false;
+}
+
+const applyFilter = useDebounceFn(
+  () => {
+    let val = unref(search);
+    val = val && val.trim();
+    if (!val) {
+      recipes.value = unref(allRecipes);
+      page.value = 1;
+      return;
+    }
+    const searchText = val
+      .toLowerCase()
+      .split(/\s+/)
+      .map((s) => s.trim());
+    recipes.value = unref(allRecipes).filter((item) =>
+      searchText.every(
+        (l) =>
+          !l ||
+          item.recipe.input.some(
+            (io) => io.product.lowerLabel.indexOf(l) > -1
+          ) ||
+          item.recipe.output.some(
+            (io) => io.product.lowerLabel.indexOf(l) > -1
+          ) ||
+          item.factory.lowerLabel.indexOf(l) > -1
+      )
+    );
+    if (unref(page) > unref(pages)) {
+      page.value = unref(pages);
+    }
+  },
+  400,
+  { maxWait: 1000 }
+);
+
+function filterShownRecipeIo(io: GameRecipeIO[]) {
+  return io.filter((i) => !(i.flags & GameRecipeIOFlags.HideInMenu));
+}
+
+watch(search, (value, oldValue) => {
+  if (oldValue != value) {
+    applyFilter();
+  }
+});
+
+defineExpose({
+  activate,
+});
+</script>
+
+<template>
+  <v-menu
+    v-model="active"
+    :style="menuStyle"
+    location="end"
+    :close-on-content-click="false"
+    @click:outside="closeMenu"
+  >
+    <template #activator="{ props }">
+      <div v-bind="props" class="menu-activator" :style="menuStyle" />
+    </template>
+    <v-list density="compact">
+      <v-list-subheader> Add consuming factory </v-list-subheader>
+      <v-list-item v-if="maxPages > 1" class="minwidth">
+        <v-text-field
+          v-model="search"
+          density="compact"
+          placeholder="Search recipes..."
+          hide-details
+          clearable
+          @click.stop
+        />
+      </v-list-item>
+      <optimized-tooltip>
+        <v-list-item
+          v-for="(item, index) in currentPage"
+          :key="index"
+          @click="recipeSelected(item)"
+        >
+          <v-list-item-title>
+            <div class="io-menu-item">
+              <icon-component
+                :image="item.factory.image"
+                :data-tooltip="item.factory.label"
+              />
+              <span class="factory-label">{{ item.factory.label }}</span>
+            </div>
+            <div class="io-menu-item recipe-row">
+              <recipes-menu-io
+                :ioarray="filterShownRecipeIo(item.recipe.input)"
+              />
+              <v-icon class="d-block" :icon="mdiArrowRight" />
+              <recipes-menu-io
+                :ioarray="filterShownRecipeIo(item.recipe.output)"
+              />
+            </div>
+          </v-list-item-title>
+        </v-list-item>
+      </optimized-tooltip>
+      <v-list-item v-if="maxPages > 1" class="minwidth">
+        <v-pagination
+          v-model="page"
+          density="compact"
+          :length="pages"
+          :total-visible="4"
+          @click.stop
+        />
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>
+
+<style scoped>
+.menu-activator {
+  position: fixed;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+.io-menu-item {
+  display: flex;
+  align-items: center;
+}
+.factory-label {
+  margin-left: 0.5rem;
+  font-weight: 500;
+}
+.recipe-row {
+  margin-top: 0.25rem;
+  padding-left: 1.5rem;
+  opacity: 0.8;
+}
+.minwidth {
+  min-width: 15rem;
+}
+</style>

--- a/site/src/components/main-panel/recipe-suggestion-menu.vue
+++ b/site/src/components/main-panel/recipe-suggestion-menu.vue
@@ -7,7 +7,7 @@ Feature: Show recipe suggestions when output is dropped in empty space
 import { GameRecipeIOFlags } from "#types/constants";
 import type { GameItem, GameRecipe, GameRecipeIO } from "#types/game-data";
 import { injectGameData } from "@/scripts/data";
-import { mdiArrowRight } from "@mdi/js";
+import { mdiArrowRight, mdiClose } from "@mdi/js";
 import { useDebounceFn } from "@vueuse/core";
 import { computed, nextTick, ref, unref, watch } from "vue";
 import type { ReadonlyPointType } from "@/scripts/geometry";
@@ -23,10 +23,7 @@ const active = ref<boolean>(false);
 const search = ref<string>("");
 const allRecipes = ref<RecipeWithFactory[]>([]);
 const recipes = ref<RecipeWithFactory[]>([]);
-const menuStyle = ref<{ left: string; top: string }>({
-  left: "0px",
-  top: "0px",
-});
+const menuPosition = ref<{ x: number; y: number }>({ x: 0, y: 0 });
 const sourceProductName = ref<string>("");
 const dropScreenPosition = ref<ReadonlyPointType>({ x: 0, y: 0 });
 
@@ -37,6 +34,15 @@ const pages = computed(() => Math.ceil(unref(recipes).length / pageSize) || 1);
 const currentPage = computed(() => {
   const start = (unref(page) - 1) * pageSize;
   return unref(recipes).slice(start, start + pageSize);
+});
+
+// Compute menu style based on position
+const menuStyle = computed(() => {
+  const pos = unref(menuPosition);
+  return {
+    left: `${pos.x}px`,
+    top: `${pos.y}px`,
+  };
 });
 
 const emit = defineEmits<{
@@ -81,9 +87,9 @@ function activate(productName: string, screenPosition: ReadonlyPointType) {
   search.value = "";
 
   // Position menu at drop location
-  menuStyle.value = {
-    left: `${screenPosition.x}px`,
-    top: `${screenPosition.y}px`,
+  menuPosition.value = {
+    x: screenPosition.x,
+    y: screenPosition.y,
   };
 
   nextTick(() => {
@@ -156,74 +162,114 @@ defineExpose({
 </script>
 
 <template>
-  <v-menu
-    v-model="active"
-    :style="menuStyle"
-    location="end"
-    :close-on-content-click="false"
-    @click:outside="closeMenu"
-  >
-    <template #activator="{ props }">
-      <div v-bind="props" class="menu-activator" :style="menuStyle" />
-    </template>
-    <v-list density="compact">
-      <v-list-subheader> Add consuming factory </v-list-subheader>
-      <v-list-item v-if="maxPages > 1" class="minwidth">
-        <v-text-field
-          v-model="search"
-          density="compact"
-          placeholder="Search recipes..."
-          hide-details
-          clearable
-          @click.stop
-        />
-      </v-list-item>
-      <optimized-tooltip>
-        <v-list-item
-          v-for="(item, index) in currentPage"
-          :key="index"
-          @click="recipeSelected(item)"
-        >
-          <v-list-item-title>
-            <div class="io-menu-item">
-              <icon-component
-                :image="item.factory.image"
-                :data-tooltip="item.factory.label"
-              />
-              <span class="factory-label">{{ item.factory.label }}</span>
-            </div>
-            <div class="io-menu-item recipe-row">
-              <recipes-menu-io
-                :ioarray="filterShownRecipeIo(item.recipe.input)"
-              />
-              <v-icon class="d-block" :icon="mdiArrowRight" />
-              <recipes-menu-io
-                :ioarray="filterShownRecipeIo(item.recipe.output)"
-              />
-            </div>
-          </v-list-item-title>
-        </v-list-item>
-      </optimized-tooltip>
-      <v-list-item v-if="maxPages > 1" class="minwidth">
-        <v-pagination
-          v-model="page"
-          density="compact"
-          :length="pages"
-          :total-visible="4"
-          @click.stop
-        />
-      </v-list-item>
-    </v-list>
-  </v-menu>
+  <Teleport to="body">
+    <!-- Backdrop for click outside -->
+    <div v-if="active" class="recipe-suggestion-backdrop" @click="closeMenu" />
+    <!-- Menu positioned at drop location -->
+    <div v-if="active" class="recipe-suggestion-menu" :style="menuStyle">
+      <v-card elevation="8" class="menu-card">
+        <v-card-title class="menu-header">
+          <span>Add consuming factory</span>
+          <v-btn
+            size="small"
+            variant="text"
+            :icon="mdiClose"
+            @click="closeMenu"
+          />
+        </v-card-title>
+        <v-divider />
+        <v-list density="compact" class="menu-list">
+          <v-list-item v-if="maxPages > 1" class="minwidth">
+            <v-text-field
+              v-model="search"
+              density="compact"
+              placeholder="Search recipes..."
+              hide-details
+              clearable
+              @click.stop
+            />
+          </v-list-item>
+          <optimized-tooltip>
+            <v-list-item
+              v-for="(item, index) in currentPage"
+              :key="index"
+              @click="recipeSelected(item)"
+            >
+              <v-list-item-title>
+                <div class="io-menu-item">
+                  <icon-component
+                    :image="item.factory.image"
+                    :data-tooltip="item.factory.label"
+                  />
+                  <span class="factory-label">{{ item.factory.label }}</span>
+                </div>
+                <div class="io-menu-item recipe-row">
+                  <recipes-menu-io
+                    :ioarray="filterShownRecipeIo(item.recipe.input)"
+                  />
+                  <v-icon class="d-block" :icon="mdiArrowRight" />
+                  <recipes-menu-io
+                    :ioarray="filterShownRecipeIo(item.recipe.output)"
+                  />
+                </div>
+              </v-list-item-title>
+            </v-list-item>
+          </optimized-tooltip>
+          <v-list-item v-if="maxPages > 1" class="minwidth">
+            <v-pagination
+              v-model="page"
+              density="compact"
+              :length="pages"
+              :total-visible="4"
+              @click.stop
+            />
+          </v-list-item>
+        </v-list>
+      </v-card>
+    </div>
+  </Teleport>
 </template>
 
 <style scoped>
-.menu-activator {
+.recipe-suggestion-backdrop {
   position: fixed;
-  width: 1px;
-  height: 1px;
-  pointer-events: none;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 9998;
+  background: transparent;
 }
+
+.recipe-suggestion-menu {
+  position: fixed;
+  z-index: 9999;
+  max-height: 80vh;
+  overflow: visible;
+}
+
+.menu-card {
+  min-width: 280px;
+  max-width: 400px;
+  max-height: 70vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.menu-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  font-size: 0.875rem;
+}
+
+.menu-list {
+  overflow-y: auto;
+  flex: 1;
+}
+
 .io-menu-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Description
When dragging an IO (input or output) from a factory and releasing it in empty space (not on another factory), a popup menu appears showing available recipes:
- **Dragging an OUTPUT** → Shows recipes that can CONSUME that item as input
- **Dragging an INPUT** → Shows recipes that PRODUCE that item as output
Selecting a recipe from the menu creates a new factory with that recipe at the drop location and automatically creates the link.
## Changes
- Added recipe-suggestion-menu.vue component with support for both consuming and producing modes
- Modified link-draggable.vue to emit events when IO is dropped in empty space
- Modified blueprint-panel.vue to handle the events and create linked factories